### PR TITLE
docs: add README and godoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,573 @@
+# linkwell
+
+A Go library for HATEOAS-style hypermedia controls, link relations ([RFC 8288](https://www.rfc-editor.org/rfc/rfc8288)), and navigation primitives. Designed for server-rendered HTML apps using HTMX, but the data types are framework-agnostic.
+
+linkwell provides:
+
+- A **link registry** for declaring relationships between pages (related, parent/child, hub-and-spoke)
+- **Breadcrumb** generation from link graphs or URL paths
+- **Hypermedia controls** — pure-data descriptors for buttons, actions, and navigation affordances
+- **Filter, table, and pagination** primitives for data-heavy views
+- **Modal** configuration with preset button sets
+- **Navigation** types with active-state computation
+- **Error controls** dispatched by HTTP status code
+
+## Install
+
+```bash
+go get github.com/catgoose/linkwell
+```
+
+Import with an alias if you prefer:
+
+```go
+import hypermedia "github.com/catgoose/linkwell"
+```
+
+## Table of Contents
+
+- [Link Registry](#link-registry)
+  - [Registering Links](#registering-links)
+  - [Ring (Symmetric Group)](#ring-symmetric-group)
+  - [Hub (Star Topology)](#hub-star-topology)
+  - [Querying Links](#querying-links)
+  - [RFC 8288 Link Header](#rfc-8288-link-header)
+- [Breadcrumbs](#breadcrumbs)
+  - [From Link Graph](#from-link-graph)
+  - [From URL Path](#from-url-path)
+  - [Bitmask Breadcrumbs](#bitmask-breadcrumbs)
+- [Controls](#controls)
+  - [Factory Functions](#factory-functions)
+  - [Control Modifiers](#control-modifiers)
+  - [HTMX Request Config](#htmx-request-config)
+- [Navigation](#navigation)
+  - [NavConfig and NavItem](#navconfig-and-navitem)
+  - [Active State](#active-state)
+- [Filters](#filters)
+  - [FilterBar](#filterbar)
+  - [Field Types](#field-types)
+  - [FilterGroup](#filtergroup)
+- [Tables and Pagination](#tables-and-pagination)
+  - [Sortable Columns](#sortable-columns)
+  - [Pagination](#pagination)
+- [Modals](#modals)
+- [Action Patterns](#action-patterns)
+  - [Resource Actions](#resource-actions)
+  - [Row Actions](#row-actions)
+  - [Form Actions](#form-actions)
+  - [Bulk Actions](#bulk-actions)
+- [Error Controls](#error-controls)
+
+## Link Registry
+
+The link registry maintains an in-memory graph of relationships between pages. Register links at startup (typically in route initialization), then query them at request time.
+
+### Registering Links
+
+`Link` registers a directional relationship. For `rel="related"`, the inverse is automatically created (symmetric).
+
+```go
+// Inventory links to Warehouses
+linkwell.Link("/inventory", "related", "/warehouses", "Warehouses")
+// The inverse "/warehouses" -> "/inventory" is auto-registered
+
+// One-way parent link
+linkwell.Link("/users/42", "up", "/users", "Users")
+```
+
+### Ring (Symmetric Group)
+
+`Ring` connects every member to every other member with `rel="related"`. Use for peer pages that should cross-link.
+
+```go
+linkwell.Ring("Logistics",
+    linkwell.Rel("/inventory", "Inventory"),
+    linkwell.Rel("/warehouses", "Warehouses"),
+    linkwell.Rel("/shipments", "Shipments"),
+)
+// Each page now links to the other two with Group="Logistics"
+```
+
+### Hub (Star Topology)
+
+`Hub` connects a center page to spokes. Spokes link back to the center with `rel="up"` but do not link to each other.
+
+```go
+linkwell.Hub("/admin", "Admin",
+    linkwell.Rel("/admin/users", "Users"),
+    linkwell.Rel("/admin/roles", "Roles"),
+    linkwell.Rel("/admin/settings", "Settings"),
+)
+```
+
+Query all hubs for site map rendering:
+
+```go
+hubs := linkwell.Hubs() // []HubEntry sorted by path
+for _, hub := range hubs {
+    fmt.Println(hub.Title, hub.Path)
+    for _, spoke := range hub.Spokes {
+        fmt.Println("  ", spoke.Title, spoke.Href)
+    }
+}
+```
+
+### Querying Links
+
+```go
+// All links for a path
+links := linkwell.LinksFor("/inventory")
+
+// Only specific relation types
+related := linkwell.LinksFor("/inventory", "related")
+parents := linkwell.LinksFor("/admin/users", "up")
+
+// Related links excluding self (for context bars)
+peers := linkwell.RelatedLinksFor("/inventory")
+
+// Full registry snapshot (for admin/debug)
+all := linkwell.AllLinks()
+paths := linkwell.SortedPaths(all)
+```
+
+### RFC 8288 Link Header
+
+Format links as a standard `Link` HTTP header:
+
+```go
+links := linkwell.LinksFor("/inventory")
+header := linkwell.LinkHeader(links)
+// </warehouses>; rel="related"; title="Warehouses", ...
+```
+
+### Dynamic Links
+
+Load and remove links at runtime (e.g., from a database):
+
+```go
+linkwell.LoadStoredLink("/projects/42", linkwell.LinkRelation{
+    Rel: "related", Href: "/teams/7", Title: "Backend Team",
+})
+
+linkwell.RemoveLink("/projects/42", "/teams/7", "related")
+```
+
+## Breadcrumbs
+
+### From Link Graph
+
+Walk the `rel="up"` chain from a path to build a breadcrumb trail. Requires links registered via `Hub` or `Link` with `rel="up"`.
+
+```go
+// Given: Hub("/admin", "Admin", Rel("/admin/users", "Users"))
+crumbs := linkwell.BreadcrumbsFromLinks("/admin/users")
+// [{Label:"Home" Href:"/"}, {Label:"Admin" Href:"/admin"}, {Label:"Users" Href:""}]
+```
+
+The terminal breadcrumb has an empty `Href` (current page, rendered as text).
+
+### From URL Path
+
+Generate breadcrumbs from URL segments. Override labels by segment index.
+
+```go
+crumbs := linkwell.BreadcrumbsFromPath("/users/42/edit", map[int]string{
+    1: "Jane Doe", // override "42" with a name
+})
+// [{Label:"Home" Href:"/"}, {Label:"users" Href:"/users"},
+//  {Label:"Jane Doe" Href:"/users/42"}, {Label:"edit" Href:""}]
+```
+
+### Bitmask Breadcrumbs
+
+For pages reachable from multiple parents, use a `?from=` bitmask to preserve navigation context.
+
+```go
+// Register origins at startup
+linkwell.RegisterFrom(linkwell.FromDashboard, linkwell.Breadcrumb{
+    Label: "Dashboard", Href: "/dashboard",
+})
+
+// In handler: parse the ?from= param and resolve breadcrumbs
+mask := linkwell.ParseFromParam(c.QueryParam("from"))
+crumbs := linkwell.ResolveFromMask(mask)
+// Home is always included at bit 0
+
+// Forward context to outbound links
+href := linkwell.FromNav("/users/42", c.QueryParam("from"))
+// "/users/42?from=3" if mask was 3
+```
+
+## Controls
+
+A `Control` is a pure-data descriptor for a hypermedia affordance (button, link, action). Templates consume controls to render the appropriate HTML element — the control itself has no rendering logic.
+
+### Factory Functions
+
+```go
+// HTMX retry button
+ctrl := linkwell.RetryButton("Retry", linkwell.HxMethodGet, "/api/data", "#content")
+
+// Danger button with confirmation dialog
+ctrl := linkwell.ConfirmAction("Delete", linkwell.HxMethodDelete, "/users/42", "#user-list", "Delete this user?")
+
+// Browser back button (no server round-trip)
+ctrl := linkwell.BackButton("Go Back")
+
+// Home navigation
+ctrl := linkwell.GoHomeButton("Go Home", "/", "body")
+
+// Plain anchor link
+ctrl := linkwell.RedirectLink("View Profile", "/users/42")
+
+// Arbitrary HTMX action
+ctrl := linkwell.HTMXAction("Archive", linkwell.HxPost("/users/42/archive", "#content"))
+
+// Dismiss button (HyperScript close)
+ctrl := linkwell.DismissButton("Close")
+
+// Report issue modal trigger
+ctrl := linkwell.ReportIssueButton("Report Issue", requestID)
+```
+
+### Control Modifiers
+
+Controls are value types. Modifiers return copies.
+
+```go
+ctrl := linkwell.RetryButton("Retry", linkwell.HxMethodGet, "/api/data", "#content").
+    WithSwap(linkwell.SwapOuterHTML).
+    WithVariant(linkwell.VariantDanger).
+    WithIcon(linkwell.IconCheck).
+    WithConfirm("Are you sure?").
+    WithDisabled(true).
+    WithErrorTarget("#inline-error")
+```
+
+### HTMX Request Config
+
+Build HTMX request attributes programmatically:
+
+```go
+req := linkwell.HxGet("/users", "#user-list")
+req = req.WithInclude("closest form")
+
+// Or build manually
+req := linkwell.HxRequestConfig{
+    Method:  linkwell.HxMethodPost,
+    URL:     "/users",
+    Target:  "#user-list",
+    Include: "closest form",
+    Vals:    `{"status":"active"}`,
+}
+
+// Convert to attribute map for interop
+attrs := req.Attrs() // map[string]string{"get": "/users", "target": "#user-list", ...}
+```
+
+## Navigation
+
+### NavConfig and NavItem
+
+`NavConfig` holds the app navigation layout. `NavItem` is a single navigation entry with optional HTMX attributes and children.
+
+```go
+nav := linkwell.NavConfig{
+    AppName:    "My App",
+    MaxVisible: 5, // overflow after 5 items
+    Items: []linkwell.NavItem{
+        {Label: "Dashboard", Href: "/dashboard", Icon: "home"},
+        {Label: "Users", Href: "/users", Icon: "users", Children: []linkwell.NavItem{
+            {Label: "Active", Href: "/users?status=active"},
+            {Label: "Invited", Href: "/users?status=invited"},
+        }},
+    },
+}
+```
+
+Bridge a `Control` to a `NavItem`:
+
+```go
+navItem := linkwell.NavItemFromControl(ctrl)
+```
+
+### Active State
+
+Set the active nav item based on the current request path. Exact match:
+
+```go
+items := linkwell.SetActiveNavItem(nav.Items, "/users")
+```
+
+Prefix match (section-level navigation):
+
+```go
+// "/users" is active when path is "/users/42/edit"
+items := linkwell.SetActiveNavItemPrefix(nav.Items, "/users/42/edit")
+```
+
+Both functions handle nested children: a parent is marked active if any child matches.
+
+## Filters
+
+### FilterBar
+
+`FilterBar` describes a filter form. The form ID enables `hx-include` from pagination/sort links.
+
+```go
+bar := linkwell.NewFilterBar("/users", "#user-table",
+    linkwell.SearchField("q", "Search users...", currentQuery),
+    linkwell.SelectField("status", "Status", currentStatus, linkwell.SelectOptions(currentStatus,
+        "", "All",
+        "active", "Active",
+        "inactive", "Inactive",
+    )),
+    linkwell.CheckboxField("verified", "Verified only", verifiedParam),
+)
+```
+
+### Field Types
+
+```go
+linkwell.SearchField(name, placeholder, value)
+linkwell.SelectField(name, label, value, options)
+linkwell.RangeField(name, label, value, min, max, step)
+linkwell.CheckboxField(name, label, value) // value: "true" or ""
+linkwell.DateField(name, label, value)
+```
+
+Build select options from flat pairs:
+
+```go
+opts := linkwell.SelectOptions(currentValue,
+    "draft", "Draft",
+    "published", "Published",
+    "archived", "Archived",
+)
+```
+
+### FilterGroup
+
+`FilterGroup` wraps a `FilterBar` and supports dynamic option updates and OOB swap fragments.
+
+```go
+group := linkwell.NewFilterGroup("/products", "#product-table",
+    linkwell.SearchField("q", "Search...", ""),
+    linkwell.SelectField("category", "Category", "", categories),
+)
+
+// Update options dynamically
+group.UpdateOptions("category", newCategories)
+
+// Get only select fields for OOB rendering
+selects := group.SelectFields()
+```
+
+## Tables and Pagination
+
+### Sortable Columns
+
+`SortableCol` creates a column descriptor with sort state and toggle URL precomputed.
+
+```go
+cols := []linkwell.TableCol{
+    linkwell.SortableCol("name", "Name", sortKey, sortDir, baseURL, "#table", "#filter-form"),
+    linkwell.SortableCol("email", "Email", sortKey, sortDir, baseURL, "#table", "#filter-form"),
+    {Key: "actions", Label: "Actions"}, // non-sortable
+}
+```
+
+Sort direction toggles: unsorted -> asc -> desc -> asc.
+
+### Pagination
+
+```go
+totalPages := linkwell.ComputeTotalPages(totalItems, perPage)
+
+info := linkwell.PageInfo{
+    BaseURL:    "/users?q=foo",
+    Page:       currentPage,
+    PerPage:    25,
+    TotalItems: totalItems,
+    TotalPages: totalPages,
+    Target:     "#user-table",
+    Include:    "#filter-form",
+}
+
+controls := linkwell.PaginationControls(info)
+// Returns nil if TotalPages <= 1
+// Controls: [First] [Prev] [1] [2] [3] [Next] [Last]
+// Current page is disabled with VariantPrimary
+```
+
+Generate a URL for a specific page:
+
+```go
+url := info.URLForPage(3) // "/users?q=foo&page=3"
+```
+
+## Modals
+
+`ModalConfig` describes everything needed to render a modal dialog.
+
+```go
+modal := linkwell.ModalConfig{
+    ID:       "delete-user-modal",
+    Title:    "Delete User",
+    Buttons:  linkwell.ModalDeleteCancel,
+    HxPost:   "/users/42/delete",
+    HxTarget: "#user-list",
+    HxSwap:   linkwell.SwapOuterHTML,
+}
+```
+
+Preset button sets:
+
+| Set | Buttons |
+|-----|---------|
+| `ModalOK` | OK |
+| `ModalYesNo` | No, Yes |
+| `ModalSaveCancel` | Cancel, Save |
+| `ModalSaveCancelReset` | Reset, Cancel, Save |
+| `ModalSubmitCancel` | Cancel, Submit |
+| `ModalConfirmCancel` | Cancel, Confirm (danger) |
+| `ModalDeleteCancel` | Cancel, Delete (danger) |
+
+Report issue modal shortcut:
+
+```go
+modal := linkwell.ReportIssueModal(requestID)
+```
+
+## Action Patterns
+
+Pre-built control sets for common CRUD and data-management patterns. All pattern functions conditionally include controls based on which URLs are provided — omit a URL to hide that action.
+
+### Resource Actions
+
+Edit + Delete controls for resource detail pages:
+
+```go
+controls := linkwell.ResourceActions(linkwell.ResourceActionCfg{
+    EditURL:     "/users/42/edit",
+    DeleteURL:   "/users/42",
+    ConfirmMsg:  "Delete this user?",
+    Target:      "#content",
+    ErrorTarget: "#error",
+})
+```
+
+### Row Actions
+
+Controls for table rows with different swap targets:
+
+```go
+// Edit swaps the row, Delete swaps the row
+controls := linkwell.RowActions(linkwell.RowActionCfg{
+    EditURL:     "/users/42/edit",
+    DeleteURL:   "/users/42",
+    RowTarget:   "#row-42",
+    ConfirmMsg:  "Delete this user?",
+    ErrorTarget: "#row-42-error",
+})
+
+// Edit swaps the row, Delete replaces the whole table
+controls := linkwell.TableRowActions(linkwell.TableRowActionCfg{
+    EditURL:     "/users/42/edit",
+    DeleteURL:   "/users/42",
+    RowTarget:   "#row-42",
+    TableTarget: "#user-table",
+    ConfirmMsg:  "Delete this user?",
+})
+```
+
+Inline edit row controls:
+
+```go
+// Existing row: Save uses PUT
+controls := linkwell.RowFormActions(linkwell.RowFormActionCfg{
+    SaveURL:      "/users/42",
+    CancelURL:    "/users/42",
+    SaveTarget:   "#row-42",
+    CancelTarget: "#row-42",
+})
+
+// New row: Save uses POST
+controls := linkwell.NewRowFormActions(linkwell.RowFormActionCfg{
+    SaveURL:      "/users",
+    CancelURL:    "/users/new/cancel",
+    SaveTarget:   "#new-row",
+    CancelTarget: "#new-row",
+})
+```
+
+### Form Actions
+
+Save + Cancel for form footers. Save uses `hx-include="closest form"`.
+
+```go
+controls := linkwell.FormActions("/users")
+```
+
+### Bulk Actions
+
+Toolbar controls for batch operations on checkbox-selected rows:
+
+```go
+controls := linkwell.BulkActions(linkwell.BulkActionCfg{
+    DeleteURL:        "/users/bulk-delete",
+    ActivateURL:      "/users/bulk-activate",
+    DeactivateURL:    "/users/bulk-deactivate",
+    TableTarget:      "#user-table",
+    CheckboxSelector: ".user-checkbox",
+})
+```
+
+### Empty State and Catalog
+
+```go
+ctrl := linkwell.EmptyStateAction("Create First User", "/users/new", "#content")
+ctrl := linkwell.CatalogRowAction("/products/42/details", "#detail-row-42")
+```
+
+## Error Controls
+
+Status-code-specific control sets for error pages:
+
+```go
+// Dispatch by status code
+controls := linkwell.ErrorControlsForStatus(404, linkwell.ErrorControlOpts{
+    HomeURL: "/",
+})
+
+// Or use individual builders
+controls := linkwell.NotFoundControls("/")           // [Back, GoHome]
+controls := linkwell.ServiceErrorControls(opts)       // [Retry?, Dismiss]
+controls := linkwell.UnauthorizedControls("/login")   // [Log In?, Dismiss]
+controls := linkwell.ForbiddenControls()              // [Back, Dismiss]
+controls := linkwell.InternalErrorControls(opts)      // [Retry?, Dismiss]
+```
+
+`ErrorContext` carries the full error state through a rendering pipeline:
+
+```go
+ec := linkwell.ErrorContext{
+    StatusCode: 500,
+    Message:    "Database connection failed",
+    Route:      "/api/users",
+    RequestID:  "abc-123",
+    Controls:   linkwell.InternalErrorControls(opts),
+    Closable:   true,
+}
+
+// Fluent modifiers
+ec = ec.WithControls(linkwell.ReportIssueButton("Report", "abc-123"))
+ec = ec.WithOOB("#error-status", "innerHTML")
+
+// Wrap as a returnable error
+return linkwell.NewHTTPError(ec)
+```
+
+## License
+
+MIT

--- a/control.go
+++ b/control.go
@@ -1,29 +1,33 @@
-// Package hypermedia provides types and helpers for HATEOAS-style hypermedia controls
-// embedded in HTMX responses. This package has no imports from this project.
+// Package linkwell provides types and helpers for HATEOAS-style hypermedia
+// controls, link relations (RFC 8288), and navigation primitives. All types are
+// pure data descriptors — they carry no rendering logic and can be consumed by
+// any template engine (templ, html/template, etc.) or serialized to JSON.
 package linkwell
 
-// ControlKind identifies the rendering strategy for a Control.
+// ControlKind identifies the rendering strategy a template should use for a
+// Control. Each kind implies a specific HTML element and behavior pattern.
 type ControlKind string
 
 const (
-	// ControlKindRetry renders an HTMX button that re-issues a request.
+	// ControlKindRetry renders an HTMX button that re-issues a failed request.
 	ControlKindRetry ControlKind = "retry"
-	// ControlKindLink renders a plain anchor element.
+	// ControlKindLink renders a plain HTML anchor (<a>) element.
 	ControlKindLink ControlKind = "link"
-	// ControlKindHTMX renders an arbitrary HTMX button using attribute spread.
+	// ControlKindHTMX renders a button with HTMX attributes spread from HxRequest.
 	ControlKindHTMX ControlKind = "htmx"
-	// ControlKindDismiss renders a HyperScript close button.
+	// ControlKindDismiss renders a close button powered by HyperScript.
 	ControlKindDismiss ControlKind = "dismiss"
-	// ControlKindBack renders a browser history.back() button.
+	// ControlKindBack renders a button that calls browser history.back().
 	ControlKindBack ControlKind = "back"
-	// ControlKindHome renders a "Go Home" navigation button.
+	// ControlKindHome renders a navigation button that redirects to the home page.
 	ControlKindHome ControlKind = "home"
-	// ControlKindReport renders an HTMX button that posts a report and triggers an alert.
+	// ControlKindReport renders an HTMX button that fetches a report modal.
 	ControlKindReport ControlKind = "report"
 )
 
-// ControlVariant determines the visual emphasis of a Control.
-// The zero value ("") renders as secondary (safe default).
+// ControlVariant determines the visual emphasis of a Control. Templates map
+// variants to CSS classes (e.g., DaisyUI btn-primary, btn-ghost). The zero
+// value ("") renders as secondary, which is a safe default.
 type ControlVariant string
 
 const (
@@ -39,8 +43,9 @@ const (
 	VariantLink ControlVariant = "link"
 )
 
-// SwapMode is a typed HTMX swap strategy for Control.Swap.
-// Defined separately from htmx.SwapStrategy to keep this package zero-dependency.
+// SwapMode is a typed HTMX swap strategy for Control.Swap. These mirror the
+// hx-swap attribute values. Defined as a separate type (rather than importing
+// an htmx package) to keep linkwell dependency-free.
 type SwapMode string
 
 // HTMX swap strategy constants.
@@ -55,8 +60,9 @@ const (
 	SwapDelete      SwapMode = "delete"
 )
 
-// Icon is a typed icon name for Control.Icon.
-// Custom values are still valid via Icon("my-icon").
+// Icon is a typed icon name for Control.Icon. The built-in constants cover
+// common actions, but any string is valid — templates interpret the value to
+// select the appropriate icon component (e.g., Heroicons, Lucide).
 type Icon string
 
 // Built-in icon name constants.
@@ -101,7 +107,8 @@ const (
 	TargetBody = "body"
 )
 
-// HxMethod is the HTTP verb used in an HTMX request attribute (hx-get, hx-post, etc.).
+// HxMethod is the HTTP verb used in an HTMX request attribute. The value maps
+// directly to the hx-get, hx-post, hx-put, hx-patch, or hx-delete attribute name.
 type HxMethod string
 
 // HTTP verb constants for HTMX request attributes.
@@ -113,17 +120,27 @@ const (
 	HxMethodDelete HxMethod = "delete"
 )
 
-// HxRequestConfig describes the HTMX request attributes for a control.
+// HxRequestConfig describes the HTMX request attributes for a control. It maps
+// to the hx-{method}, hx-target, hx-include, and hx-vals attributes. Use the
+// HxGet, HxPost, HxPut, HxPatch, and HxDelete helpers for common cases, or
+// build directly for full control.
 type HxRequestConfig struct {
-	Method  HxMethod
-	URL     string
-	Target  string
+	// Method is the HTTP verb (maps to hx-get, hx-post, etc.).
+	Method HxMethod
+	// URL is the request endpoint.
+	URL string
+	// Target is the CSS selector for hx-target.
+	Target string
+	// Include is the CSS selector for hx-include (e.g., "closest form").
 	Include string
-	Vals    string // JSON-encoded hx-vals for form data (e.g. `{"status":"active"}`)
+	// Vals is a JSON-encoded string for hx-vals (e.g., `{"status":"active"}`).
+	Vals string
 }
 
-// Attrs converts the config to a map[string]string for interop with NavItem,
-// FilterField, or other consumers that use generic attribute maps.
+// Attrs converts the config to a map[string]string suitable for attribute
+// spreading in templates. Keys are the HTMX attribute suffixes (e.g., "get",
+// "target", "include", "vals"). Used for interop with NavItem.HTMXAttrs and
+// other consumers that accept generic attribute maps.
 func (r HxRequestConfig) Attrs() map[string]string {
 	m := make(map[string]string, 4)
 	if r.URL != "" {
@@ -166,26 +183,42 @@ func HxDelete(url, target string) HxRequestConfig {
 	return HxRequestConfig{Method: HxMethodDelete, URL: url, Target: target}
 }
 
-// Control is a pure-data descriptor for a single hypermedia affordance.
-// Templ components consume these to render the appropriate HTML element.
+// Control is a pure-data descriptor for a single hypermedia affordance — a
+// button, link, or action that a user can take. Templates consume controls to
+// render the appropriate HTML elements with the correct HTMX attributes,
+// confirmation dialogs, icons, and visual styles. Controls are value types;
+// use the With* methods to derive modified copies.
 type Control struct {
-	HxRequest   HxRequestConfig
-	Kind        ControlKind
-	Label       string
-	Href        string
-	Variant     ControlVariant
-	Confirm     string
-	Icon        Icon
-	PushURL     string
-	Swap        SwapMode
-	Disabled    bool
+	// HxRequest carries the HTMX request attributes (method, URL, target, etc.).
+	HxRequest HxRequestConfig
+	// Kind determines how the template renders this control (button, link, etc.).
+	Kind ControlKind
+	// Label is the user-visible text for the control.
+	Label string
+	// Href is the URL for link-type controls (ControlKindLink, ControlKindHome).
+	Href string
+	// Variant sets the visual emphasis (primary, danger, ghost, etc.).
+	Variant ControlVariant
+	// Confirm is an optional hx-confirm message shown before the action executes.
+	Confirm string
+	// Icon is an optional icon name rendered alongside the label.
+	Icon Icon
+	// PushURL is set on navigation controls to update the browser URL via hx-push-url.
+	PushURL string
+	// Swap overrides the default hx-swap strategy for this control.
+	Swap SwapMode
+	// Disabled renders the control in a non-interactive state.
+	Disabled bool
+	// ErrorTarget overrides the parent hx-target-error so error responses render
+	// inline near this control rather than in a global error container.
 	ErrorTarget string
-	ModalID     string
+	// ModalID ties this control to a specific modal dialog.
+	ModalID string
 }
 
-// RetryButton creates an HTMX button that re-issues a request using the given method.
-// method must be one of: "get", "post", "put", "delete", "patch".
-// target is the CSS selector for hx-target.
+// RetryButton creates a primary-variant HTMX button that re-issues a failed
+// request. Typically used in error states to let the user retry the operation
+// that produced the error.
 func RetryButton(label string, method HxMethod, url, target string) Control {
 	return Control{
 		Kind:      ControlKindRetry,
@@ -195,8 +228,9 @@ func RetryButton(label string, method HxMethod, url, target string) Control {
 	}
 }
 
-// ConfirmAction creates a danger-variant HTMX button with an hx-confirm gate.
-// Use for destructive operations that require user confirmation before proceeding.
+// ConfirmAction creates a danger-variant HTMX button with an hx-confirm
+// confirmation dialog. Use for destructive operations (delete, archive) where
+// the user should explicitly confirm before the request is sent.
 func ConfirmAction(label string, method HxMethod, url, target, confirmMsg string) Control {
 	return Control{
 		Kind:      ControlKindHTMX,
@@ -207,8 +241,8 @@ func ConfirmAction(label string, method HxMethod, url, target, confirmMsg string
 	}
 }
 
-// BackButton creates a browser history.back() control rendered via HyperScript.
-// No server round-trip occurs.
+// BackButton creates a client-side browser history.back() control. No server
+// round-trip occurs — the template renders this as a HyperScript-powered button.
 func BackButton(label string) Control {
 	return Control{
 		Kind:  ControlKindBack,
@@ -216,7 +250,8 @@ func BackButton(label string) Control {
 	}
 }
 
-// GoHomeButton creates a "Go Home" navigation control that pushes homeURL to browser history.
+// GoHomeButton creates a navigation control that loads the home page via HTMX
+// GET and pushes homeURL to browser history via hx-push-url.
 func GoHomeButton(label, homeURL, target string) Control {
 	return Control{
 		Kind:      ControlKindHome,
@@ -227,7 +262,7 @@ func GoHomeButton(label, homeURL, target string) Control {
 	}
 }
 
-// RedirectLink creates a same-tab anchor control.
+// RedirectLink creates a plain anchor (<a>) control for same-tab navigation.
 func RedirectLink(label, href string) Control {
 	return Control{
 		Kind:  ControlKindLink,
@@ -236,7 +271,9 @@ func RedirectLink(label, href string) Control {
 	}
 }
 
-// HTMXAction creates an arbitrary HTMX button using the supplied request config.
+// HTMXAction creates an HTMX button with the supplied request config. Use when
+// the preset factory functions do not fit — this gives full control over the
+// HTMX attributes while still producing a typed Control.
 func HTMXAction(label string, req HxRequestConfig) Control {
 	return Control{
 		Kind:      ControlKindHTMX,
@@ -245,9 +282,9 @@ func HTMXAction(label string, req HxRequestConfig) Control {
 	}
 }
 
-// ReportIssueButton creates a button that fetches the Report Issue modal via
-// HTMX GET. The server returns the modal fragment with collected log data; the
-// modal auto-opens on load.
+// ReportIssueButton creates an HTMX button that fetches the Report Issue modal
+// via GET to /report-issue (or /report-issue/{requestID} if provided). The
+// server returns the modal fragment which auto-opens on load.
 func ReportIssueButton(label, requestID string) Control {
 	url := "/report-issue"
 	if requestID != "" {
@@ -260,7 +297,8 @@ func ReportIssueButton(label, requestID string) Control {
 	}
 }
 
-// DismissButton creates a HyperScript-powered dismiss control.
+// DismissButton creates a HyperScript-powered close/dismiss control. Typically
+// used to close error banners, notifications, or alert panels.
 func DismissButton(label string) Control {
 	return Control{
 		Kind:  ControlKindDismiss,
@@ -268,44 +306,46 @@ func DismissButton(label string) Control {
 	}
 }
 
-// WithSwap returns a copy with the given swap mode.
+// WithSwap returns a copy of the control with the given HTMX swap strategy.
 func (c Control) WithSwap(s SwapMode) Control {
 	c.Swap = s
 	return c
 }
 
-// WithVariant returns a copy with the given variant.
+// WithVariant returns a copy of the control with the given visual variant.
 func (c Control) WithVariant(v ControlVariant) Control {
 	c.Variant = v
 	return c
 }
 
-// WithConfirm returns a copy with the given confirmation message.
+// WithConfirm returns a copy of the control with the given hx-confirm message.
 func (c Control) WithConfirm(msg string) Control {
 	c.Confirm = msg
 	return c
 }
 
-// WithIcon returns a copy with the given icon.
+// WithIcon returns a copy of the control with the given icon name.
 func (c Control) WithIcon(i Icon) Control {
 	c.Icon = i
 	return c
 }
 
-// WithDisabled returns a copy with the disabled flag set.
+// WithDisabled returns a copy of the control with the given disabled state.
 func (c Control) WithDisabled(d bool) Control {
 	c.Disabled = d
 	return c
 }
 
-// WithErrorTarget returns a copy with the given hx-target-error selector.
-// This overrides the parent hx-target-error so error responses render inline.
+// WithErrorTarget returns a copy of the control with the given hx-target-error
+// CSS selector, overriding any parent error target so error responses render
+// inline near this control.
 func (c Control) WithErrorTarget(target string) Control {
 	c.ErrorTarget = target
 	return c
 }
 
-// WithInclude returns a copy with the given include selector.
+// WithInclude returns a copy of the request config with the given hx-include
+// CSS selector.
 func (r HxRequestConfig) WithInclude(selector string) HxRequestConfig {
 	r.Include = selector
 	return r

--- a/error.go
+++ b/error.go
@@ -2,42 +2,60 @@ package linkwell
 
 import "fmt"
 
-// DefaultErrorStatusTarget is the CSS selector for the error status container.
-// Used by OOB placements and the response builder to target the error panel.
+// DefaultErrorStatusTarget is the CSS selector for the error status container
+// used by OOB placements and response builders to target the error panel.
 const DefaultErrorStatusTarget = "#error-status"
 
-// ErrorContext is the single struct that flows through the hypermedia error pipeline.
-// It carries all information needed to render a richly-linked error response.
+// ErrorContext carries all information needed to render a hypermedia error
+// response with action controls. It flows through the error handling pipeline
+// from handler to middleware to template. Use WithControls and WithOOB to build
+// up the context fluently.
 type ErrorContext struct {
-	Err        error
-	Message    string
-	Route      string
-	RequestID  string
-	OOBTarget  string
-	OOBSwap    string
-	Controls   []Control
+	// Err is the underlying Go error (not shown to users, used for logging).
+	Err error
+	// Message is the user-facing error message.
+	Message string
+	// Route is the request path that produced the error (for logging/reporting).
+	Route string
+	// RequestID is the correlation ID for the request (passed to ReportIssueButton).
+	RequestID string
+	// OOBTarget is the CSS selector for an HTMX OOB swap target. When set, the
+	// error renders as an out-of-band fragment rather than the main response.
+	OOBTarget string
+	// OOBSwap is the hx-swap-oob strategy (e.g., "innerHTML", "outerHTML").
+	OOBSwap string
+	// Controls is the set of hypermedia affordances rendered with the error
+	// (e.g., Retry, Back, Dismiss buttons).
+	Controls []Control
+	// StatusCode is the HTTP status code for the error response.
 	StatusCode int
-	Closable   bool
-	Theme      string // DaisyUI theme for full-page error renders; empty = "dark"
+	// Closable indicates whether the error panel should show a close/dismiss button.
+	Closable bool
+	// Theme is the DaisyUI theme for full-page error renders. Empty defaults to "dark".
+	Theme string
 }
 
-// WithControls returns a copy of the ErrorContext with the given controls appended.
+// WithControls returns a copy of the ErrorContext with the given controls
+// appended to the existing set. The original is not modified.
 func (ec ErrorContext) WithControls(controls ...Control) ErrorContext {
 	ec.Controls = append(append([]Control(nil), ec.Controls...), controls...)
 	return ec
 }
 
-// WithOOB returns a copy of the ErrorContext configured for OOB rendering.
+// WithOOB returns a copy of the ErrorContext configured for HTMX out-of-band
+// swap rendering. Set target to the CSS selector and swap to the hx-swap-oob
+// strategy (e.g., "innerHTML").
 func (ec ErrorContext) WithOOB(target, swap string) ErrorContext {
 	ec.OOBTarget = target
 	ec.OOBSwap = swap
 	return ec
 }
 
-// HTTPError is a returnable error that wraps an ErrorContext.
-// middleware.ErrorHandlerMiddleware detects it via errors.As and renders
-// the full hypermedia error response including action controls.
+// HTTPError is a Go error that wraps an ErrorContext. Return it from handlers
+// and let error-handling middleware detect it via errors.As to render the full
+// hypermedia error response with action controls.
 type HTTPError struct {
+	// EC is the error context carrying the status code, message, and controls.
 	EC ErrorContext
 }
 
@@ -48,8 +66,9 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP %d: %s", e.EC.StatusCode, e.EC.Message)
 }
 
-// NewHTTPError wraps an ErrorContext in an HTTPError ready to be returned
-// from a handler. The error handler middleware will intercept and render it.
+// NewHTTPError wraps an ErrorContext in an HTTPError suitable for returning
+// from a handler. The error handler middleware intercepts it and renders the
+// appropriate hypermedia error response.
 func NewHTTPError(ec ErrorContext) *HTTPError {
 	return &HTTPError{EC: ec}
 }

--- a/filter.go
+++ b/filter.go
@@ -1,6 +1,8 @@
 package linkwell
 
-// FilterKind identifies the input type for a FilterField.
+// FilterKind identifies the HTML input type for a FilterField. Templates use
+// this to select the appropriate form control (text input, select, range slider,
+// checkbox, or date picker).
 type FilterKind string
 
 // Filter kind constants for FilterField.Kind.
@@ -12,44 +14,65 @@ const (
 	FilterKindDate     FilterKind = "date"
 )
 
-// FilterOption is a single option in a select dropdown.
+// FilterOption is a single option in a select dropdown. Selected is typically
+// set by SelectOptions based on the current query parameter value.
 type FilterOption struct {
 	Value    string
 	Label    string
 	Selected bool
 }
 
-// FilterField is a pure-data descriptor for a single filter input.
-// Value always holds the current serialized value (string) regardless of Kind.
-// For checkboxes: Value == "true" means checked; "" means unchecked (param absent).
-// For range: Value is the current numeric string; Min/Max/Step bound the slider.
+// FilterField is a pure-data descriptor for a single filter input. Value always
+// holds the current serialized value as a string regardless of Kind:
+//   - Search/Select/Date: the query parameter value
+//   - Checkbox: "true" when checked, "" when unchecked (param absent)
+//   - Range: the current numeric string; Min/Max/Step bound the slider
 type FilterField struct {
-	HTMXAttrs   map[string]string
-	Kind        FilterKind
-	Name        string
-	Label       string
+	// HTMXAttrs holds optional HTMX attributes for this field (e.g., for
+	// cascading filter updates triggered by hx-get on change).
+	HTMXAttrs map[string]string
+	// Kind determines the HTML input type rendered by the template.
+	Kind FilterKind
+	// Name is the form field name (maps to the query parameter key).
+	Name string
+	// Label is the visible label text. Used by select, range, checkbox, and date.
+	Label string
+	// Placeholder is hint text for search inputs.
 	Placeholder string
-	Value       string
-	Min         string
-	Max         string
-	Step        string
-	Options     []FilterOption
-	Disabled    bool
+	// Value is the current serialized value from the query string.
+	Value string
+	// Min is the minimum value for range inputs.
+	Min string
+	// Max is the maximum value for range inputs.
+	Max string
+	// Step is the increment step for range inputs.
+	Step string
+	// Options is the list of choices for select inputs.
+	Options []FilterOption
+	// Disabled renders the field in a non-interactive state.
+	Disabled bool
 }
 
-// FilterBar is the descriptor for the full filter form.
-// The form element has ID so pagination/sort links can use hx-include="#filter-form".
+// FilterBar is the descriptor for a complete filter form. The form element
+// carries an HTML id so that pagination and sort links can use
+// hx-include="#filter-form" to forward filter state with their requests.
 type FilterBar struct {
-	ID     string // HTML form id (default "filter-form")
-	Action string // hx-get endpoint (e.g., "/users")
-	Target string // hx-target CSS selector (e.g., "#table-container")
+	// ID is the HTML form id attribute. Defaults to DefaultFilterFormID ("filter-form")
+	// when created via NewFilterBar.
+	ID string
+	// Action is the hx-get endpoint the form submits to (e.g., "/users").
+	Action string
+	// Target is the hx-target CSS selector (e.g., "#table-container").
+	Target string
+	// Fields is the ordered list of filter inputs rendered in the form.
 	Fields []FilterField
 }
 
 // DefaultFilterFormID is the HTML form id used by NewFilterBar.
 const DefaultFilterFormID = "filter-form"
 
-// NewFilterBar creates a FilterBar with ID=DefaultFilterFormID.
+// NewFilterBar creates a FilterBar with the default form ID and the given
+// action endpoint, HTMX target, and fields.
 func NewFilterBar(action, target string, fields ...FilterField) FilterBar {
 	return FilterBar{
 		ID:     DefaultFilterFormID,
@@ -59,7 +82,8 @@ func NewFilterBar(action, target string, fields ...FilterField) FilterBar {
 	}
 }
 
-// SearchField creates a text search input.
+// SearchField creates a text search input with the given name, placeholder, and
+// current value.
 func SearchField(name, placeholder, value string) FilterField {
 	return FilterField{
 		Kind:        FilterKindSearch,
@@ -69,7 +93,8 @@ func SearchField(name, placeholder, value string) FilterField {
 	}
 }
 
-// SelectField creates a <select> dropdown.
+// SelectField creates a select dropdown with the given options. Use
+// SelectOptions to build the options slice from flat value/label pairs.
 func SelectField(name, label, value string, options []FilterOption) FilterField {
 	return FilterField{
 		Kind:    FilterKindSelect,
@@ -80,7 +105,7 @@ func SelectField(name, label, value string, options []FilterOption) FilterField 
 	}
 }
 
-// RangeField creates a range slider.
+// RangeField creates a range slider input bounded by min, max, and step.
 func RangeField(name, label, value, min, max, step string) FilterField {
 	return FilterField{
 		Kind:  FilterKindRange,
@@ -93,8 +118,8 @@ func RangeField(name, label, value, min, max, step string) FilterField {
 	}
 }
 
-// CheckboxField creates a boolean toggle.
-// value should be c.QueryParam(name) — "true" if checked, "" if unchecked/absent.
+// CheckboxField creates a boolean toggle. Pass the raw query parameter value:
+// "true" when checked, "" when unchecked or absent.
 func CheckboxField(name, label, value string) FilterField {
 	return FilterField{
 		Kind:  FilterKindCheckbox,
@@ -104,7 +129,7 @@ func CheckboxField(name, label, value string) FilterField {
 	}
 }
 
-// DateField creates a date input.
+// DateField creates a date picker input.
 func DateField(name, label, value string) FilterField {
 	return FilterField{
 		Kind:  FilterKindDate,
@@ -114,9 +139,9 @@ func DateField(name, label, value string) FilterField {
 	}
 }
 
-// SelectOptions builds a []FilterOption from flat pairs ["val","Label",...].
-// current is matched against Value to set Selected=true.
-// Odd pairs are handled safely by ignoring the trailing unpaired value.
+// SelectOptions builds a slice of FilterOption from flat value/label pairs.
+// The current parameter is matched against each value to set Selected=true on
+// the matching option. Unpaired trailing values are safely ignored.
 func SelectOptions(current string, pairs ...string) []FilterOption {
 	options := make([]FilterOption, 0, len(pairs)/2)
 	for i := 0; i+1 < len(pairs); i += 2 {
@@ -131,22 +156,24 @@ func SelectOptions(current string, pairs ...string) []FilterOption {
 	return options
 }
 
-// FilterGroup is a configuration group of filter controls that can produce
-// OOB swap fragments when the available options change. It wraps a FilterBar
-// and adds the ability to update select field options and render OOB updates
-// using data-filter attributes instead of element IDs.
+// FilterGroup wraps a FilterBar with methods for dynamic option updates and
+// OOB (out-of-band) swap rendering. Use when filter options change based on
+// other selections (e.g., cascading dropdowns) and the server needs to push
+// updated select elements back to the page via HTMX OOB swaps.
 type FilterGroup struct {
+	// Bar is the underlying filter bar configuration.
 	Bar FilterBar
 }
 
-// NewFilterGroup creates a FilterGroup with the given fields.
+// NewFilterGroup creates a FilterGroup with a default-ID FilterBar.
 func NewFilterGroup(action, target string, fields ...FilterField) FilterGroup {
 	return FilterGroup{
 		Bar: NewFilterBar(action, target, fields...),
 	}
 }
 
-// UpdateOptions replaces the options for the named select field.
+// UpdateOptions replaces the options for the named select field. Non-select
+// fields or unrecognized names are silently ignored.
 func (g *FilterGroup) UpdateOptions(name string, options []FilterOption) {
 	for i := range g.Bar.Fields {
 		if g.Bar.Fields[i].Name == name && g.Bar.Fields[i].Kind == FilterKindSelect {
@@ -156,7 +183,9 @@ func (g *FilterGroup) UpdateOptions(name string, options []FilterOption) {
 	}
 }
 
-// SelectFields returns only the select-type fields for OOB rendering.
+// SelectFields returns only the select-type fields from the bar. Use when
+// rendering OOB swap fragments that update dropdown options without replacing
+// the entire filter form.
 func (g *FilterGroup) SelectFields() []FilterField {
 	var fields []FilterField
 	for _, f := range g.Bar.Fields {

--- a/link_types.go
+++ b/link_types.go
@@ -5,34 +5,49 @@ import (
 	"strings"
 )
 
-// LinkRelation represents a relationship between two resources.
+// LinkRelation represents a typed relationship between two resources, following
+// the IANA link relation model defined in RFC 8288. Each relation carries a
+// relation type (Rel), target URL (Href), human-readable label (Title), and an
+// optional group name for UI rendering (e.g., the ring or hub name).
 type LinkRelation struct {
-	Rel   string // IANA link relation (e.g., "related", "collection", "up")
-	Href  string // Target URL
-	Title string // Human-readable label
-	Group string // Optional group name (e.g., ring name) for UI grouping
+	// Rel is the IANA link relation type (e.g., "related", "collection", "up").
+	// See https://www.iana.org/assignments/link-relations/ for registered values.
+	Rel string
+	// Href is the target URL of the linked resource.
+	Href string
+	// Title is a human-readable label for the link, suitable for rendering in
+	// navigation bars, context panels, or breadcrumb trails.
+	Title string
+	// Group is an optional grouping label set by Ring or Hub registration.
+	// Templates can use this to visually cluster related links.
+	Group string
 }
 
-// RelEntry is a path+title pair for use with Ring and Hub.
+// RelEntry is a path and title pair used as input to Ring and Hub registration.
+// Create instances with the Rel helper function.
 type RelEntry struct {
 	Path  string
 	Title string
 }
 
-// Rel creates a RelEntry for use with Ring and Hub.
+// Rel creates a RelEntry for use with Ring and Hub. This is the preferred
+// constructor for building the member lists passed to those functions.
 func Rel(path, title string) RelEntry {
 	return RelEntry{Path: path, Title: title}
 }
 
-// HubEntry represents a hub center with its spoke links for site map rendering.
+// HubEntry represents a hub center with its spoke links, returned by Hubs
+// for site map or navigation tree rendering. Spokes are sorted alphabetically
+// by title.
 type HubEntry struct {
 	Path   string
 	Title  string
 	Spokes []LinkRelation
 }
 
-// TitleFromPath extracts a title from the last segment of a URL path.
-// "/demo/inventory" -> "Inventory", "/admin/error-traces" -> "Error Traces"
+// TitleFromPath derives a human-readable title from the last segment of a URL
+// path. Hyphens are replaced with spaces and each word is title-cased.
+// Examples: "/demo/inventory" -> "Inventory", "/admin/error-traces" -> "Error Traces".
 func TitleFromPath(path string) string {
 	path = strings.TrimSuffix(path, "/")
 	idx := strings.LastIndex(path, "/")
@@ -51,7 +66,9 @@ func TitleFromPath(path string) string {
 	return strings.Join(words, " ")
 }
 
-// LinkHeader formats link relations as an RFC 8288 Link header value.
+// LinkHeader formats a slice of LinkRelation values as an RFC 8288 Link header
+// string. Each relation is rendered as `<href>; rel="type"; title="label"`,
+// joined by commas. Returns an empty string if links is empty.
 func LinkHeader(links []LinkRelation) string {
 	if len(links) == 0 {
 		return ""

--- a/links.go
+++ b/links.go
@@ -7,6 +7,7 @@ import (
 )
 
 // linkRegistry stores registered link relations keyed by source path.
+// Protected by linksMu for concurrent access.
 var (
 	linksMu  sync.RWMutex
 	linksMap = make(map[string][]LinkRelation)
@@ -15,8 +16,11 @@ var (
 	hubsMap = make(map[string]string) // path -> title
 )
 
-// Link registers a relationship from a source path to a target.
-// For rel="related", the inverse is automatically registered (symmetric).
+// Link registers a directional relationship from a source path to a target.
+// The rel parameter should be an IANA link relation type (e.g., "related", "up",
+// "collection"). For rel="related", the inverse link is automatically created
+// so the relationship is symmetric — both pages will see each other in their
+// link sets. Registration is safe for concurrent use.
 func Link(source, rel, target, title string) {
 	linksMu.Lock()
 	defer linksMu.Unlock()
@@ -40,8 +44,9 @@ func Link(source, rel, target, title string) {
 	}
 }
 
-// LinksFor returns all registered link relations for a path.
-// If rels is provided, only relations matching those types are returned.
+// LinksFor returns all registered link relations for the given path. If one or
+// more rel types are provided, only relations matching those types are returned.
+// Returns a copy of the internal slice, safe to modify.
 func LinksFor(path string, rels ...string) []LinkRelation {
 	linksMu.RLock()
 	defer linksMu.RUnlock()
@@ -67,8 +72,9 @@ func LinksFor(path string, rels ...string) []LinkRelation {
 	return filtered
 }
 
-// RelatedLinksFor returns only rel="related" links for a path,
-// excluding the current path itself (for use in context bars).
+// RelatedLinksFor returns only rel="related" links for a path, excluding the
+// path itself and deduplicating by href. Useful for rendering context bars or
+// "See also" panels where self-links would be redundant.
 func RelatedLinksFor(path string) []LinkRelation {
 	links := LinksFor(path, "related")
 	// Deduplicate by href (symmetric registration can create dupes)
@@ -84,8 +90,10 @@ func RelatedLinksFor(path string) []LinkRelation {
 	return unique
 }
 
-// Ring registers symmetric rel="related" links between all members.
-// Every member links to every other member. The name is used for UI grouping.
+// Ring registers symmetric rel="related" links between all members, creating a
+// fully-connected group where every member links to every other member. The name
+// parameter is stored as the Group field on each LinkRelation for UI grouping.
+// Duplicate links are skipped. Registration is safe for concurrent use.
 func Ring(name string, members ...RelEntry) {
 	linksMu.Lock()
 	defer linksMu.Unlock()
@@ -107,9 +115,11 @@ func Ring(name string, members ...RelEntry) {
 	}
 }
 
-// Hub registers a center page that links to all spokes, and each spoke
-// links back to the center only. Spokes do not link to each other.
-// The centerTitle is used as the group name for all links.
+// Hub registers a star topology where a center page links to all spokes via
+// rel="related", and each spoke links back to the center via rel="up". Spokes
+// do not link to each other. The centerTitle is used as the Group field on all
+// links and as the hub label returned by Hubs. Registration is safe for
+// concurrent use.
 func Hub(centerPath, centerTitle string, spokes ...RelEntry) {
 	hubsMu.Lock()
 	hubsMap[centerPath] = centerTitle
@@ -150,8 +160,9 @@ func hasLink(links []LinkRelation, href, rel string) bool {
 	return false
 }
 
-// AllLinks returns all registered link relations grouped by source path.
-// Used for admin/debug inspection.
+// AllLinks returns a snapshot of all registered link relations grouped by
+// source path. The returned map and slices are copies, safe to modify. Useful
+// for admin dashboards or debug pages that inspect the link graph.
 func AllLinks() map[string][]LinkRelation {
 	linksMu.RLock()
 	defer linksMu.RUnlock()
@@ -165,7 +176,8 @@ func AllLinks() map[string][]LinkRelation {
 	return result
 }
 
-// SortedPaths returns all registered source paths in sorted order.
+// SortedPaths returns the keys of a link map in alphabetical order. Pass the
+// result of AllLinks to get a stable iteration order for rendering.
 func SortedPaths(links map[string][]LinkRelation) []string {
 	paths := make([]string, 0, len(links))
 	for k := range links {
@@ -175,8 +187,9 @@ func SortedPaths(links map[string][]LinkRelation) []string {
 	return paths
 }
 
-// Hubs returns all registered hub centers with their spokes, sorted by path.
-// Spokes within each hub are sorted alphabetically by title.
+// Hubs returns all registered hub centers with their spoke links, sorted by
+// center path. Spokes within each hub are sorted alphabetically by title. Use
+// for rendering site maps or navigation trees.
 func Hubs() []HubEntry {
 	hubsMu.RLock()
 	paths := make([]string, 0, len(hubsMap))
@@ -204,8 +217,10 @@ func Hubs() []HubEntry {
 	return entries
 }
 
-// BreadcrumbsFromLinks walks the rel="up" chain from path to build a breadcrumb trail.
-// Returns nil if no rel="up" links are registered for the path.
+// BreadcrumbsFromLinks walks the rel="up" chain from path to build a
+// breadcrumb trail. The trail starts with Home, includes each ancestor found
+// via rel="up" links, and ends with the current page (empty Href). Returns nil
+// if no rel="up" links are registered for the path. Cycle-safe.
 func BreadcrumbsFromLinks(path string) []Breadcrumb {
 	var crumbs []Breadcrumb
 	visited := map[string]bool{}
@@ -240,8 +255,9 @@ func BreadcrumbsFromLinks(path string) []Breadcrumb {
 	return crumbs
 }
 
-// LoadStoredLink adds a single link relation from an external source (e.g., database)
-// into the in-memory registry. Skips duplicates.
+// LoadStoredLink adds a single link relation from an external source (e.g., a
+// database or configuration file) into the in-memory registry. Duplicate links
+// (same source, href, and rel) are silently skipped.
 func LoadStoredLink(source string, r LinkRelation) {
 	linksMu.Lock()
 	defer linksMu.Unlock()
@@ -250,8 +266,9 @@ func LoadStoredLink(source string, r LinkRelation) {
 	}
 }
 
-// RemoveLink removes a link relation matching source, href, and rel from the
-// in-memory registry. Returns true if a link was removed.
+// RemoveLink removes the first link relation matching source, href, and rel
+// from the in-memory registry. Returns true if a link was found and removed,
+// false if no match was found.
 func RemoveLink(source, href, rel string) bool {
 	linksMu.Lock()
 	defer linksMu.Unlock()
@@ -268,7 +285,9 @@ func RemoveLink(source, href, rel string) bool {
 	return false
 }
 
-// ResetForTesting clears the global link registry. Test use only.
+// ResetForTesting clears all entries from the global link and hub registries.
+// Intended for use in test setup/teardown only — not safe to call in production
+// while handlers may be reading the registry.
 func ResetForTesting() {
 	linksMu.Lock()
 	linksMap = make(map[string][]LinkRelation)

--- a/modal.go
+++ b/modal.go
@@ -1,6 +1,8 @@
 package linkwell
 
-// ModalButtonRole identifies the semantic role of a modal button.
+// ModalButtonRole identifies the semantic role of a button within a modal
+// dialog. Templates use this to determine behavior: primary buttons submit,
+// cancel buttons dismiss, and secondary buttons perform auxiliary actions.
 type ModalButtonRole string
 
 const (
@@ -12,14 +14,19 @@ const (
 	ModalRoleSecondary ModalButtonRole = "secondary"
 )
 
-// ModalButton describes a single button inside a modal.
+// ModalButton describes a single button inside a modal dialog footer.
 type ModalButton struct {
-	Label   string
-	Role    ModalButtonRole
+	// Label is the button text.
+	Label string
+	// Role determines the button's behavior (submit, cancel, auxiliary).
+	Role ModalButtonRole
+	// Variant sets the visual style of the button.
 	Variant ControlVariant
 }
 
-// ModalButtonSet is an ordered list of buttons for a modal footer.
+// ModalButtonSet is an ordered list of buttons for a modal footer. Buttons
+// render left-to-right in the order they appear in the slice. Use the preset
+// variables (ModalOK, ModalYesNo, etc.) for common patterns.
 type ModalButtonSet []ModalButton
 
 // Preset modal button sets.
@@ -54,21 +61,29 @@ var (
 	}
 )
 
-// ModalConfig describes everything needed to render a modal.
+// ModalConfig describes everything needed to render a modal dialog. The ID
+// must be unique on the page. When HxPost is set, the primary button submits
+// the modal's form content via HTMX POST.
 type ModalConfig struct {
-	ID      string
-	Title   string
+	// ID is the unique HTML id for the modal element.
+	ID string
+	// Title is displayed in the modal header.
+	Title string
+	// Buttons defines the footer button set.
 	Buttons ModalButtonSet
-	// HxPost is the URL for the primary button's hx-post attribute.
-	// When set, the primary button submits the modal's form via HTMX.
+	// HxPost is the URL for the primary button's hx-post attribute. When empty,
+	// the primary button uses client-side behavior only (e.g., close on confirm).
 	HxPost string
-	// HxTarget is the hx-target selector for the primary button's HTMX request.
+	// HxTarget is the hx-target CSS selector for the primary button's HTMX
+	// response.
 	HxTarget string
-	// HxSwap is the hx-swap strategy for the primary button's HTMX request.
+	// HxSwap is the hx-swap strategy for the primary button's HTMX response.
 	HxSwap SwapMode
 }
 
-// ReportIssueModal returns a ModalConfig for the Report Issue flow.
+// ReportIssueModal returns a ModalConfig preconfigured for the Report Issue
+// flow. The modal posts to /report-issue (or /report-issue/{requestID}) with
+// SwapNone so the response triggers a toast/alert without replacing DOM content.
 func ReportIssueModal(requestID string) ModalConfig {
 	url := "/report-issue"
 	if requestID != "" {

--- a/nav.go
+++ b/nav.go
@@ -10,40 +10,63 @@ import (
 	"github.com/a-h/templ"
 )
 
-// NavConfig holds the app-controlled parts of the nav layout.
-// Zero values are safe: no promoted item, all items visible, no custom slots.
+// NavConfig holds the app-controlled parts of the navigation layout. Zero
+// values are safe defaults: no promoted item, all items visible, no custom
+// brand or topbar slots.
 type NavConfig struct {
-	Items      []NavItem       // Navigation items
-	Promoted   *NavItem        // Optional promoted FAB item (mobile)
-	MaxVisible int             // Items visible before overflow (0 = show all)
-	AppName    string          // Brand text
-	Brand      templ.Component // Custom brand slot (replaces default appName text)
-	Topbar     templ.Component // Custom mobile topbar content (replaces default)
+	// Items is the ordered list of navigation entries.
+	Items []NavItem
+	// Promoted is an optional floating action button item shown on mobile.
+	Promoted *NavItem
+	// MaxVisible limits how many items are shown before overflowing into a
+	// "more" menu. Zero means show all items.
+	MaxVisible int
+	// AppName is plain text displayed in the brand area of the navigation bar.
+	AppName string
+	// Brand is an optional templ component that replaces the default AppName
+	// text in the brand slot. Set to nil to use the plain text AppName.
+	Brand templ.Component
+	// Topbar is an optional templ component that replaces the default mobile
+	// topbar content. Set to nil to use the default layout.
+	Topbar templ.Component
 }
 
-// NavItem is a server-computed navigation affordance.
-// Active state is set by the handler (or SetActiveNavItem), not by JavaScript.
+// NavItem is a server-computed navigation entry. Active state is determined by
+// the handler (via SetActiveNavItem or SetActiveNavItemPrefix), not by
+// client-side JavaScript. Items may have children for dropdown/flyout menus.
 type NavItem struct {
+	// HTMXAttrs holds optional HTMX attributes (e.g., from HxRequestConfig.Attrs())
+	// for items that trigger HTMX requests instead of full navigation.
 	HTMXAttrs map[string]string
-	Label     string
-	Href      string
-	Icon      string
-	Children  []NavItem
-	Active    bool
+	// Label is the user-visible text for this navigation entry.
+	Label string
+	// Href is the navigation target URL.
+	Href string
+	// Icon is the icon name rendered alongside the label.
+	Icon string
+	// Children are nested sub-items for dropdown menus.
+	Children []NavItem
+	// Active indicates this item matches the current page. Set by SetActiveNavItem
+	// or SetActiveNavItemPrefix, or manually by the handler.
+	Active bool
 }
 
-// Breadcrumb is one segment of a breadcrumb trail.
-// Href empty means this is the current page (rendered as text, not an anchor).
+// Breadcrumb is one segment of a breadcrumb trail. When Href is empty, the
+// segment represents the current page and should be rendered as plain text
+// rather than a clickable link.
 type Breadcrumb struct {
+	// Label is the display text for this breadcrumb segment.
 	Label string
-	Href  string
+	// Href is the navigation target. Empty for the terminal (current page) segment.
+	Href string
 }
 
 // BreadcrumbLabelHome is the default label for the root breadcrumb segment.
 const BreadcrumbLabelHome = "Home"
 
-// SetActiveNavItem performs exact-match active state setting.
-// A parent item is marked active if any of its children match.
+// SetActiveNavItem sets the Active flag on nav items using exact path matching.
+// A parent item is also marked active if any of its children match. Returns a
+// new slice; the input is not modified.
 func SetActiveNavItem(items []NavItem, currentPath string) []NavItem {
 	result := make([]NavItem, len(items))
 	for i, item := range items {
@@ -61,9 +84,11 @@ func SetActiveNavItem(items []NavItem, currentPath string) []NavItem {
 	return result
 }
 
-// SetActiveNavItemPrefix performs longest-prefix match active state setting.
-// Use for section-level nav: /users is active when path is /users/42/edit.
-// A parent item is marked active if any of its children match.
+// SetActiveNavItemPrefix sets the Active flag using longest-prefix matching.
+// An item is active if the current path equals its Href or starts with Href
+// followed by "/". Use for section-level navigation where /users should be
+// active when the path is /users/42/edit. A parent is marked active if any
+// child matches. Returns a new slice; the input is not modified.
 func SetActiveNavItemPrefix(items []NavItem, currentPath string) []NavItem {
 	result := make([]NavItem, len(items))
 	for i, item := range items {
@@ -84,7 +109,9 @@ func SetActiveNavItemPrefix(items []NavItem, currentPath string) []NavItem {
 	return result
 }
 
-// NavItemFromControl bridges a Control to a NavItem (Label, Href, Icon, HTMXAttrs).
+// NavItemFromControl converts a Control into a NavItem, mapping Label, Href,
+// Icon, and HxRequest attributes. Useful when a control needs to appear in the
+// navigation bar.
 func NavItemFromControl(ctrl Control) NavItem {
 	return NavItem{
 		Label:     ctrl.Label,
@@ -94,9 +121,11 @@ func NavItemFromControl(ctrl Control) NavItem {
 	}
 }
 
-// BreadcrumbsFromPath generates crumbs from a URL path.
-// labels overrides auto-generated labels by segment index (0-based, not counting the Home crumb).
-// The terminal segment always has an empty Href (rendered as plain text).
+// BreadcrumbsFromPath generates a breadcrumb trail from a URL path by splitting
+// on "/" and title-casing each segment. The labels map overrides auto-generated
+// labels by segment index (0-based, not counting the Home crumb) — use this to
+// replace opaque IDs with human-readable names. The terminal segment always has
+// an empty Href (rendered as text, not a link).
 func BreadcrumbsFromPath(path string, labels map[int]string) []Breadcrumb {
 	trimmed := strings.Trim(path, "/")
 	if trimmed == "" {
@@ -119,12 +148,15 @@ func BreadcrumbsFromPath(path string, labels map[int]string) []Breadcrumb {
 	return crumbs
 }
 
-// FromBit is a bitmask position for a registered breadcrumb origin.
-// Lower bits render earlier in the trail. Bit 0 is reserved for Home.
+// FromBit is a bitmask position for a registered breadcrumb origin. Lower bits
+// render earlier in the trail. Bit 0 is reserved for Home and is always
+// included. Use RegisterFrom to associate a Breadcrumb with a bit position,
+// then pass a bitmask via the ?from= query parameter to reconstruct the trail.
 type FromBit = uint64
 
 // Well-known breadcrumb bit positions. Bit 0 (Home) is always included.
-// Register additional bits via RegisterFrom.
+// Register additional bits via RegisterFrom. Bits 2-7 are available for
+// application-specific origins.
 const (
 	FromHome      FromBit = 1 << iota // bit 0 — always shown
 	FromDashboard                     // bit 1
@@ -152,8 +184,9 @@ func init() {
 	RegisterFrom(FromHome, Breadcrumb{Label: BreadcrumbLabelHome, Href: "/"})
 }
 
-// RegisterFrom registers a breadcrumb at the given bit position.
-// Call during route initialization. Bit 0 is pre-registered as Home.
+// RegisterFrom registers a breadcrumb at the given bit position. Call during
+// route initialization. Bit 0 is pre-registered as Home. If the bit is already
+// registered, the previous entry is replaced.
 func RegisterFrom(bit FromBit, crumb Breadcrumb) {
 	fromMu.Lock()
 	// Replace if bit already registered.
@@ -171,9 +204,11 @@ func RegisterFrom(bit FromBit, crumb Breadcrumb) {
 	fromMu.Unlock()
 }
 
-// ResolveFromMask decodes a bitmask into an ordered breadcrumb trail.
-// Only registered bits are included. Unregistered bits are silently ignored.
-// Home (bit 0) is always included regardless of the mask value.
+// ResolveFromMask decodes a bitmask into an ordered breadcrumb trail by
+// checking each registered bit position. Only registered bits are included;
+// unregistered bits are silently ignored. Home (bit 0) is always included
+// regardless of the mask value. Entries are ordered by bit position (lowest
+// first).
 func ResolveFromMask(mask uint64) []Breadcrumb {
 	mask |= FromHome // always include Home
 	fromMu.RLock()
@@ -188,8 +223,8 @@ func ResolveFromMask(mask uint64) []Breadcrumb {
 	return crumbs
 }
 
-// ParseFromParam parses the ?from= query parameter as a uint64 bitmask.
-// Returns 0 if empty or invalid.
+// ParseFromParam parses the ?from= query parameter string as a uint64 bitmask.
+// Returns 0 if the input is empty or not a valid unsigned integer.
 func ParseFromParam(raw string) uint64 {
 	if raw == "" {
 		return 0
@@ -198,13 +233,14 @@ func ParseFromParam(raw string) uint64 {
 	return v
 }
 
-// FromParam formats a bitmask as a string suitable for ?from= query values.
+// FromParam formats a bitmask as a decimal string suitable for ?from= query
+// parameter values.
 func FromParam(mask uint64) string {
 	return strconv.FormatUint(mask, 10)
 }
 
-// FromQueryString returns "from=N" for use in URL query strings.
-// Returns empty string if mask is 0.
+// FromQueryString returns "from=N" formatted for inclusion in URL query
+// strings. Returns an empty string if mask is 0 (no origin context).
 func FromQueryString(mask uint64) string {
 	if mask == 0 {
 		return ""
@@ -212,8 +248,9 @@ func FromQueryString(mask uint64) string {
 	return fmt.Sprintf("from=%s", FromParam(mask))
 }
 
-// FromNav appends the from parameter to a href if non-empty.
-// Use in templates to forward breadcrumb context to outbound links.
+// FromNav appends the ?from= parameter to a href, preserving any existing
+// query string. Returns href unchanged if from is empty. Use in templates to
+// forward breadcrumb context to outbound links.
 func FromNav(href, from string) string {
 	if from == "" {
 		return href

--- a/patterns.go
+++ b/patterns.go
@@ -1,13 +1,20 @@
 package linkwell
 
-// ErrorControlOpts carries context for building status-code-specific molecules.
-// Zero values are safe: missing fields omit the corresponding control.
+// ErrorControlOpts carries context for building status-code-specific control
+// sets. Zero values are safe: missing fields cause the corresponding control to
+// be omitted from the result. For example, omitting RetryURL skips the Retry
+// button; omitting HomeURL skips the GoHome button.
 type ErrorControlOpts struct {
-	RetryMethod HxMethod // defaults to HxMethodGet if zero
-	RetryURL    string   // typically c.Request().URL.String()
-	RetryTarget string   // CSS selector for hx-target on retry
-	HomeURL     string   // for GoHome control; typically "/"
-	LoginURL    string   // for Unauthorized; typically "/login"
+	// RetryMethod is the HTTP method for the retry button. Defaults to GET if empty.
+	RetryMethod HxMethod
+	// RetryURL is the request URL to retry (typically the current request URL).
+	RetryURL string
+	// RetryTarget is the CSS selector for hx-target on the retry button.
+	RetryTarget string
+	// HomeURL is the home page URL for the GoHome button (typically "/").
+	HomeURL string
+	// LoginURL is the login page URL for the Log In button (typically "/login").
+	LoginURL string
 }
 
 func resolveRetryMethod(opts ErrorControlOpts) HxMethod {
@@ -17,7 +24,8 @@ func resolveRetryMethod(opts ErrorControlOpts) HxMethod {
 	return opts.RetryMethod
 }
 
-// NotFoundControls returns [Back] and optionally [GoHome] controls for a 404 error.
+// NotFoundControls returns [Back] and optionally [GoHome] controls for a 404
+// response. Pass an empty homeURL to omit the GoHome button.
 func NotFoundControls(homeURL string) []Control {
 	controls := []Control{BackButton(LabelGoBack)}
 	if homeURL != "" {
@@ -26,7 +34,8 @@ func NotFoundControls(homeURL string) []Control {
 	return controls
 }
 
-// ServiceErrorControls returns [Retry?] + [Dismiss] controls for a 503 error.
+// ServiceErrorControls returns [Retry, Dismiss] controls for a 503 response.
+// The Retry button is omitted if opts.RetryURL is empty.
 func ServiceErrorControls(opts ErrorControlOpts) []Control {
 	controls := []Control{}
 	if opts.RetryURL != "" {
@@ -36,7 +45,8 @@ func ServiceErrorControls(opts ErrorControlOpts) []Control {
 	return controls
 }
 
-// UnauthorizedControls returns [Log In?] + [Dismiss] controls for a 401 error.
+// UnauthorizedControls returns [Log In, Dismiss] controls for a 401 response.
+// The Log In button is omitted if loginURL is empty.
 func UnauthorizedControls(loginURL string) []Control {
 	controls := []Control{}
 	if loginURL != "" {
@@ -46,7 +56,7 @@ func UnauthorizedControls(loginURL string) []Control {
 	return controls
 }
 
-// ForbiddenControls returns [Back] + [Dismiss] controls for a 403 error.
+// ForbiddenControls returns [Back, Dismiss] controls for a 403 response.
 func ForbiddenControls() []Control {
 	return []Control{
 		BackButton(LabelGoBack),
@@ -54,7 +64,8 @@ func ForbiddenControls() []Control {
 	}
 }
 
-// InternalErrorControls returns [Retry?] + [Dismiss] controls for a 500 error.
+// InternalErrorControls returns [Retry, Dismiss] controls for a 500 response.
+// The Retry button is omitted if opts.RetryURL is empty.
 func InternalErrorControls(opts ErrorControlOpts) []Control {
 	controls := []Control{}
 	if opts.RetryURL != "" {
@@ -64,8 +75,9 @@ func InternalErrorControls(opts ErrorControlOpts) []Control {
 	return controls
 }
 
-// ErrorControlsForStatus dispatches to the appropriate molecule by HTTP status code.
-// Use in generic middleware or catch-all error handlers.
+// ErrorControlsForStatus dispatches to the appropriate control builder based on
+// HTTP status code. Returns a [Dismiss] control for unrecognized status codes.
+// Use in generic error-handling middleware.
 func ErrorControlsForStatus(statusCode int, opts ErrorControlOpts) []Control {
 	switch statusCode {
 	case 404:
@@ -83,56 +95,66 @@ func ErrorControlsForStatus(statusCode int, opts ErrorControlOpts) []Control {
 	}
 }
 
-// RowActionCfg configures Edit + Delete controls for a table row.
+// RowActionCfg configures Edit + Delete controls for a table row. Both the Edit
+// and Delete actions target the same row element (RowTarget) with outerHTML swap.
 type RowActionCfg struct {
-	EditURL     string
-	DeleteURL   string
-	RowTarget   string
-	ConfirmMsg  string
-	ErrorTarget string
+	EditURL     string // GET URL to fetch the edit form for this row.
+	DeleteURL   string // DELETE URL to remove this row.
+	RowTarget   string // CSS selector for the row element (e.g., "#row-42").
+	ConfirmMsg  string // hx-confirm message for the delete action.
+	ErrorTarget string // CSS selector for inline error display.
 }
 
-// TableRowActionCfg configures Edit (swap row) + Delete (replace table) controls.
+// TableRowActionCfg configures Edit + Delete controls where Edit swaps the
+// individual row (RowTarget) and Delete replaces the entire table
+// (TableTarget). Use when deleting a row requires re-rendering the full table
+// (e.g., to update row numbers or totals).
 type TableRowActionCfg struct {
-	EditURL     string
-	DeleteURL   string
-	RowTarget   string
-	TableTarget string
-	ConfirmMsg  string
-	ErrorTarget string
+	EditURL     string // GET URL to fetch the edit form for this row.
+	DeleteURL   string // DELETE URL to remove this row.
+	RowTarget   string // CSS selector for the row element.
+	TableTarget string // CSS selector for the table container.
+	ConfirmMsg  string // hx-confirm message for the delete action.
+	ErrorTarget string // CSS selector for inline error display.
 }
 
-// RowFormActionCfg configures Save + Cancel controls for inline edit rows.
+// RowFormActionCfg configures Save + Cancel controls for inline table row
+// editing. RowFormActions uses PUT for existing rows; NewRowFormActions uses
+// POST for new rows.
 type RowFormActionCfg struct {
-	SaveURL      string
-	CancelURL    string
-	SaveTarget   string
-	CancelTarget string
-	ErrorTarget  string
+	SaveURL      string // PUT or POST URL for saving the row.
+	CancelURL    string // GET URL to restore the display row.
+	SaveTarget   string // CSS selector for the save response target.
+	CancelTarget string // CSS selector for the cancel response target.
+	ErrorTarget  string // CSS selector for inline error display.
 }
 
-// ResourceActionCfg configures Edit + Delete controls for resource detail pages.
+// ResourceActionCfg configures Edit + Delete controls for resource detail
+// pages (as opposed to table rows). Both actions target the same content area.
 type ResourceActionCfg struct {
-	EditURL     string
-	DeleteURL   string
-	ConfirmMsg  string
-	Target      string
-	ErrorTarget string
+	EditURL     string // GET URL to fetch the edit form.
+	DeleteURL   string // DELETE URL to remove the resource.
+	ConfirmMsg  string // hx-confirm message for the delete action.
+	Target      string // CSS selector for the content area.
+	ErrorTarget string // CSS selector for inline error display.
 }
 
-// BulkActionCfg configures batch operation controls for checkbox-selected rows.
+// BulkActionCfg configures toolbar controls for batch operations on
+// checkbox-selected table rows. Each URL is optional — omit to hide that
+// action. The CheckboxSelector is the CSS selector for row checkboxes included
+// via hx-include.
 type BulkActionCfg struct {
-	DeleteURL        string
-	ActivateURL      string
-	DeactivateURL    string
-	TableTarget      string
-	CheckboxSelector string
-	ErrorTarget      string
+	DeleteURL        string // DELETE URL for bulk deletion.
+	ActivateURL      string // PUT URL for bulk activation.
+	DeactivateURL    string // PUT URL for bulk deactivation.
+	TableTarget      string // CSS selector for the table to replace after the operation.
+	CheckboxSelector string // CSS selector for row checkboxes (e.g., ".user-checkbox").
+	ErrorTarget      string // CSS selector for inline error display.
 }
 
 // ResourceActions returns Edit + Delete controls for resource detail pages.
-// Controls are conditionally included: omit EditURL to hide Edit, omit DeleteURL
-// to hide Delete. Returns an empty slice if both are empty.
+// Controls are conditionally included: omit EditURL to hide Edit, omit
+// DeleteURL to hide Delete. Returns an empty slice if both URLs are empty.
 func ResourceActions(cfg ResourceActionCfg) []Control {
 	controls := []Control{}
 	if cfg.EditURL != "" {
@@ -154,9 +176,10 @@ func ResourceActions(cfg ResourceActionCfg) []Control {
 	return controls
 }
 
-// FormActions returns [Save (primary)] + [Cancel (ghost)] controls for form footers.
-// The Save button uses hx-include="closest form"; the parent form must carry the
-// hx-post or hx-put attribute that drives the submission.
+// FormActions returns [Save, Cancel] controls for form footers. The Save button
+// uses hx-include="closest form" to submit the form data; the parent form
+// element must carry the hx-post or hx-put attribute that drives submission.
+// The Cancel button is a plain link to cancelHref.
 func FormActions(cancelHref string) []Control {
 	return []Control{
 		{
@@ -176,9 +199,9 @@ func FormActions(cancelHref string) []Control {
 	}
 }
 
-// RowActions returns Edit + Delete controls for a table row.
-// Controls are conditionally included: omit EditURL to hide Edit, omit DeleteURL
-// to hide Delete. Returns an empty slice if both are empty.
+// RowActions returns Edit + Delete controls for a table row where both actions
+// swap the same row target with outerHTML. Controls are conditionally included:
+// omit EditURL to hide Edit, omit DeleteURL to hide Delete.
 func RowActions(cfg RowActionCfg) []Control {
 	controls := []Control{}
 	if cfg.EditURL != "" {
@@ -206,9 +229,9 @@ func RowActions(cfg RowActionCfg) []Control {
 	return controls
 }
 
-// TableRowActions returns Edit (swap row outerHTML) + Delete (replace tableTarget outerHTML).
-// Controls are conditionally included: omit EditURL to hide Edit, omit DeleteURL
-// to hide Delete. Returns an empty slice if both are empty.
+// TableRowActions returns Edit + Delete controls where Edit swaps the row and
+// Delete replaces the entire table container. Controls are conditionally
+// included: omit EditURL to hide Edit, omit DeleteURL to hide Delete.
 func TableRowActions(cfg TableRowActionCfg) []Control {
 	controls := []Control{}
 	if cfg.EditURL != "" {
@@ -236,9 +259,10 @@ func TableRowActions(cfg TableRowActionCfg) []Control {
 	return controls
 }
 
-// RowFormActions returns Save (hx-put) + Cancel controls for an inline edit row.
-// Controls are conditionally included: omit SaveURL to hide Save, omit CancelURL
-// to hide Cancel. Returns an empty slice if both are empty.
+// RowFormActions returns Save + Cancel controls for an inline edit row. Save
+// uses hx-put with hx-include="closest tr" to submit the row's form fields.
+// Controls are conditionally included: omit SaveURL to hide Save, omit
+// CancelURL to hide Cancel.
 func RowFormActions(cfg RowFormActionCfg) []Control {
 	controls := []Control{}
 	if cfg.SaveURL != "" {
@@ -266,9 +290,10 @@ func RowFormActions(cfg RowFormActionCfg) []Control {
 	return controls
 }
 
-// NewRowFormActions returns Save (hx-post) + Cancel controls for a new-item inline form row.
-// Controls are conditionally included: omit SaveURL to hide Save, omit CancelURL
-// to hide Cancel. Returns an empty slice if both are empty.
+// NewRowFormActions returns Save + Cancel controls for a new-item inline form
+// row. Save uses hx-post (instead of hx-put) with hx-include="closest tr".
+// Controls are conditionally included: omit SaveURL to hide Save, omit
+// CancelURL to hide Cancel.
 func NewRowFormActions(cfg RowFormActionCfg) []Control {
 	controls := []Control{}
 	if cfg.SaveURL != "" {
@@ -296,7 +321,8 @@ func NewRowFormActions(cfg RowFormActionCfg) []Control {
 	return controls
 }
 
-// EmptyStateAction returns a single primary CTA for empty list states.
+// EmptyStateAction returns a single primary call-to-action control for empty
+// list states (e.g., "Create First User" when a table has no rows).
 func EmptyStateAction(label, createURL, target string) Control {
 	return Control{
 		Kind:      ControlKindHTMX,
@@ -306,8 +332,9 @@ func EmptyStateAction(label, createURL, target string) Control {
 	}
 }
 
-// CatalogRowAction returns a Details button that fills the adjacent placeholder row via innerHTML.
-// detailRowTarget is the CSS selector for the placeholder <tr>, e.g. "#detail-row-42".
+// CatalogRowAction returns a ghost-variant Details button that fills an
+// adjacent placeholder row via innerHTML swap. Use for catalog/listing views
+// where clicking a row loads detail content into an expandable area below it.
 func CatalogRowAction(detailURL, detailRowTarget string) Control {
 	return Control{
 		Kind:      ControlKindHTMX,
@@ -318,9 +345,9 @@ func CatalogRowAction(detailURL, detailRowTarget string) Control {
 	}
 }
 
-// BulkActions returns toolbar controls for batch operations on checkbox-selected rows.
-// Controls are conditionally included: omit DeleteURL, ActivateURL, or DeactivateURL
-// to hide the corresponding control. Returns an empty slice if all are empty.
+// BulkActions returns toolbar controls for batch operations on
+// checkbox-selected rows. Controls are conditionally included: omit DeleteURL,
+// ActivateURL, or DeactivateURL to hide the corresponding action.
 func BulkActions(cfg BulkActionCfg) []Control {
 	controls := []Control{}
 	if cfg.DeleteURL != "" {

--- a/table.go
+++ b/table.go
@@ -5,7 +5,8 @@ import (
 	"strconv"
 )
 
-// SortDir indicates the current sort direction for a column.
+// SortDir indicates the current sort direction for a table column. The zero
+// value (SortNone) means the column is not currently sorted.
 type SortDir string
 
 // Sort direction constants for TableCol.SortDir.
@@ -30,28 +31,51 @@ const (
 	PaginationLast  = "»"
 )
 
-// TableCol is a pure-data column descriptor.
-// Sort metadata is precomputed by the handler — templates just render it.
+// TableCol is a pure-data column descriptor for a table header. Sort metadata
+// (direction, toggle URL) is precomputed by the handler so templates render
+// without logic. Non-sortable columns leave SortURL empty.
 type TableCol struct {
-	Key      string
-	Label    string
-	SortDir  SortDir
-	SortURL  string
-	Target   string
-	Include  string
-	Width    string
+	// Key identifies the column (maps to the "sort" query parameter value).
+	Key string
+	// Label is the visible column header text.
+	Label string
+	// SortDir is the current sort direction for this column.
+	SortDir SortDir
+	// SortURL is the HTMX request URL that toggles the sort direction. Built by
+	// SortableCol with the next direction pre-encoded.
+	SortURL string
+	// Target is the CSS selector for hx-target on the sort link.
+	Target string
+	// Include is the CSS selector for hx-include on the sort link (e.g.,
+	// "#filter-form" to forward filter state).
+	Include string
+	// Width is an optional CSS width hint (e.g., "120px", "20%").
+	Width string
+	// Sortable indicates whether the column header renders as a clickable sort link.
 	Sortable bool
 }
 
-// PageInfo carries server-computed pagination state.
+// PageInfo carries server-computed pagination state used by PaginationControls
+// to generate the page navigation bar. All fields are set by the handler; the
+// template just passes PageInfo through.
 type PageInfo struct {
-	BaseURL    string
-	PageParam  string
-	Target     string
-	Include    string
-	Page       int
-	PerPage    int
+	// BaseURL is the current URL (with existing query params preserved).
+	// URLForPage appends/replaces the page parameter.
+	BaseURL string
+	// PageParam overrides the query parameter name for the page number.
+	// Defaults to "page" when empty.
+	PageParam string
+	// Target is the CSS selector for hx-target on pagination links.
+	Target string
+	// Include is the CSS selector for hx-include (e.g., "#filter-form").
+	Include string
+	// Page is the current 1-based page number.
+	Page int
+	// PerPage is the number of items per page.
+	PerPage int
+	// TotalItems is the total number of items across all pages.
 	TotalItems int
+	// TotalPages is the total number of pages. Use ComputeTotalPages to calculate.
 	TotalPages int
 }
 
@@ -63,7 +87,8 @@ func (pi PageInfo) pageParam() string {
 	return pi.PageParam
 }
 
-// URLForPage builds the URL for a specific page using net/url for correct encoding.
+// URLForPage builds the URL for a specific page number by appending or
+// replacing the page query parameter in BaseURL.
 func (pi PageInfo) URLForPage(page int) string {
 	u, err := url.Parse(pi.BaseURL)
 	if err != nil {
@@ -75,7 +100,8 @@ func (pi PageInfo) URLForPage(page int) string {
 	return u.String()
 }
 
-// ComputeTotalPages returns ceil(totalItems / perPage); minimum 1.
+// ComputeTotalPages calculates the number of pages needed to display
+// totalItems at the given perPage size. Always returns at least 1.
 func ComputeTotalPages(totalItems, perPage int) int {
 	if perPage <= 0 {
 		return 1
@@ -90,12 +116,12 @@ func ComputeTotalPages(totalItems, perPage int) int {
 	return pages
 }
 
-// SortableCol creates a TableCol with sort state and toggle URL computed from current request.
-// baseURL: current URL with "sort" and "dir" params already stripped.
-// Toggle logic:
-//   - non-matching key → SortNone, URL points to asc.
-//   - matching key + asc → SortAsc, URL toggles to desc.
-//   - matching key + desc → SortDesc, URL toggles to asc.
+// SortableCol creates a TableCol with precomputed sort state and toggle URL.
+// Pass the current sort key and direction from the request's query parameters.
+// The baseURL should have "sort" and "dir" params already stripped. Toggle
+// logic: clicking an unsorted column sorts ascending, clicking the active
+// ascending column toggles to descending, and clicking the active descending
+// column toggles back to ascending.
 func SortableCol(key, label, currentSortKey, currentSortDir, baseURL, target, include string) TableCol {
 	col := TableCol{
 		Key:      key,
@@ -138,14 +164,11 @@ func SortableCol(key, label, currentSortKey, currentSortDir, baseURL, target, in
 	return col
 }
 
-// PaginationControls generates the []Control slice for a PaginationBar.
-// Exported so it can be tested independently.
-// Returns nil if TotalPages <= 1.
-// Control semantics:
-//
-//	Current page:       Kind=ControlKindHTMX, Disabled=true, Variant=VariantPrimary
-//	Disabled boundary:  Kind=ControlKindHTMX, Disabled=true
-//	Normal page/nav:    Kind=ControlKindHTMX, HxRequest={Method: HxMethodGet, URL: url, Target: ..., Include: ...}
+// PaginationControls generates the control slice for a pagination bar. Returns
+// nil if TotalPages <= 1 (no pagination needed). The returned controls follow
+// a [First][Prev][page window][Next][Last] layout. The current page is rendered
+// as a disabled primary-variant control; boundary controls (First/Prev at page
+// 1, Next/Last at last page) are disabled.
 func PaginationControls(info PageInfo) []Control {
 	if info.TotalPages <= 1 {
 		return nil


### PR DESCRIPTION
## Summary

- Add comprehensive README.md with organized usage examples covering the full API surface: link registry (Link/Ring/Hub), breadcrumbs, controls, navigation, filters, tables/pagination, modals, action patterns, and error handling
- Add godoc comments to every exported type, field, function, and constant across all 9 source files (~1,700 lines)
- Fix package doc comment to reference the correct package name (linkwell, not hypermedia)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes (all existing tests still pass)
- [ ] Review README examples match the actual API signatures
- [ ] Verify godoc rendering on pkg.go.dev after merge

Closes #2, closes #3