### PR TITLE
refactor: optional templ dep, thread-safe registry docs, API cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/catgoose/linkwell
 
 go 1.26.1
 
-require (
-	github.com/a-h/templ v0.3.1001
-	github.com/stretchr/testify v1.10.0
-)
+require github.com/stretchr/testify v1.10.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/a-h/templ v0.3.1001 h1:yHDTgexACdJttyiyamcTHXr2QkIeVF1MukLy44EAhMY=
-github.com/a-h/templ v0.3.1001/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/links.go
+++ b/links.go
@@ -6,8 +6,19 @@ import (
 	"sync"
 )
 
-// linkRegistry stores registered link relations keyed by source path.
-// Protected by linksMu for concurrent access.
+// Thread safety
+//
+// All registry operations (Link, Ring, Hub, LinksFor, AllLinks, Hubs,
+// LoadStoredLink, RemoveLink) are protected by sync.RWMutex and are safe for
+// concurrent use. The typical usage pattern is init-time registration: call
+// Link, Ring, and Hub during route setup (before the server starts accepting
+// requests), then read with LinksFor, AllLinks, Hubs, etc. at request time.
+// Concurrent registration from multiple goroutines is supported but unusual.
+//
+// ResetForTesting clears the registries and is intended for test
+// setup/teardown only. It must not be called concurrently with request
+// handlers. In parallel tests, use t.Cleanup(ResetForTesting) within each
+// subtest to avoid cross-test pollution.
 var (
 	linksMu  sync.RWMutex
 	linksMap = make(map[string][]LinkRelation)
@@ -176,9 +187,8 @@ func AllLinks() map[string][]LinkRelation {
 	return result
 }
 
-// SortedPaths returns the keys of a link map in alphabetical order. Pass the
-// result of AllLinks to get a stable iteration order for rendering.
-func SortedPaths(links map[string][]LinkRelation) []string {
+// sortedPaths returns the keys of a link map in alphabetical order.
+func sortedPaths(links map[string][]LinkRelation) []string {
 	paths := make([]string, 0, len(links))
 	for k := range links {
 		paths = append(paths, k)
@@ -287,7 +297,9 @@ func RemoveLink(source, href, rel string) bool {
 
 // ResetForTesting clears all entries from the global link and hub registries.
 // Intended for use in test setup/teardown only — not safe to call in production
-// while handlers may be reading the registry.
+// while handlers may be reading the registry. In parallel tests, call
+// ResetForTesting at the start of each subtest and register it with t.Cleanup
+// to avoid cross-test pollution.
 func ResetForTesting() {
 	linksMu.Lock()
 	linksMap = make(map[string][]LinkRelation)

--- a/links_test.go
+++ b/links_test.go
@@ -340,7 +340,7 @@ func TestSortedPaths(t *testing.T) {
 	Link("/m", "up", "/a", "A")
 
 	all := AllLinks()
-	paths := SortedPaths(all)
+	paths := sortedPaths(all)
 	// /a gets auto-registered from symmetric "related"
 	assert.True(t, len(paths) >= 3)
 	for i := 1; i < len(paths); i++ {

--- a/nav.go
+++ b/nav.go
@@ -1,14 +1,22 @@
 package linkwell
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
-
-	"github.com/a-h/templ"
 )
+
+// Renderable is a minimal rendering interface satisfied by templ.Component and
+// any type that can render itself to an io.Writer. Using this interface instead
+// of templ.Component directly allows consumers that don't use templ to avoid
+// pulling in the templ module.
+type Renderable interface {
+	Render(ctx context.Context, w io.Writer) error
+}
 
 // NavConfig holds the app-controlled parts of the navigation layout. Zero
 // values are safe defaults: no promoted item, all items visible, no custom
@@ -23,12 +31,14 @@ type NavConfig struct {
 	MaxVisible int
 	// AppName is plain text displayed in the brand area of the navigation bar.
 	AppName string
-	// Brand is an optional templ component that replaces the default AppName
-	// text in the brand slot. Set to nil to use the plain text AppName.
-	Brand templ.Component
-	// Topbar is an optional templ component that replaces the default mobile
-	// topbar content. Set to nil to use the default layout.
-	Topbar templ.Component
+	// Brand is an optional component that replaces the default AppName text in
+	// the brand slot. Any templ.Component satisfies Renderable. Set to nil to
+	// use the plain text AppName.
+	Brand Renderable
+	// Topbar is an optional component that replaces the default mobile topbar
+	// content. Any templ.Component satisfies Renderable. Set to nil to use the
+	// default layout.
+	Topbar Renderable
 }
 
 // NavItem is a server-computed navigation entry. Active state is determined by
@@ -174,6 +184,9 @@ type fromEntry struct {
 	crumb Breadcrumb
 }
 
+// Protected by fromMu. RegisterFrom and ResolveFromMask are safe for
+// concurrent use. Registration is expected at init time; reads happen at
+// request time.
 var (
 	fromMu      sync.RWMutex
 	fromEntries []fromEntry


### PR DESCRIPTION
## Summary

- **Issue #4**: Define `Renderable` interface (`Render(ctx context.Context, w io.Writer) error`) that `templ.Component` already satisfies. `NavConfig.Brand` and `NavConfig.Topbar` now use `Renderable` instead of `templ.Component`. The `github.com/a-h/templ` module dependency is removed entirely.
- **Issue #5**: Document the thread safety model for the link, hub, and from-bit registries. All registry operations are mutex-protected and safe for concurrent use. The expected pattern (init-time registration, request-time reads) is now documented. `ResetForTesting` parallel test guidance added.
- **Issue #6**: Unexport `SortedPaths` to `sortedPaths` -- trivial sort helper that doesn't need to be in the public API.

Closes #4, closes #5, closes #6