### PR TITLE
fix: lift visited check into loop condition (QF1006)

### DIFF
--- a/links.go
+++ b/links.go
@@ -236,10 +236,7 @@ func BreadcrumbsFromLinks(path string) []Breadcrumb {
 	visited := map[string]bool{}
 	current := path
 
-	for {
-		if visited[current] {
-			break // prevent cycles
-		}
+	for !visited[current] {
 		visited[current] = true
 
 		upLinks := LinksFor(current, "up")


### PR DESCRIPTION
## Summary

- Fixes staticcheck QF1006 lint failure on `links.go:240` by lifting the `visited[current]` check from an `if/break` inside a `for {}` loop into the loop condition itself (`for !visited[current]`).

## Test plan

- [ ] `golangci-lint run` passes with 0 issues
- [ ] Existing tests pass