### PR TITLE
feat: breadcrumb path walk-up and ResolveFromMaskWithPath helper

### DIFF
--- a/links.go
+++ b/links.go
@@ -3,6 +3,7 @@ package linkwell
 
 import (
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -230,11 +231,36 @@ func Hubs() []HubEntry {
 // BreadcrumbsFromLinks walks the rel="up" chain from path to build a
 // breadcrumb trail. The trail starts with Home, includes each ancestor found
 // via rel="up" links, and ends with the current page (empty Href). Returns nil
-// if no rel="up" links are registered for the path. Cycle-safe.
+// if no rel="up" links are registered for the path.
+//
+// When the exact path has no rel="up" links, BreadcrumbsFromLinks strips the
+// last path segment and retries up the hierarchy until a registered path is
+// found. Intermediate segments between the matched ancestor and the original
+// path are included as breadcrumbs. This allows child pages like
+// /admin/groups/new to inherit breadcrumbs from /admin/groups. Cycle-safe.
 func BreadcrumbsFromLinks(path string) []Breadcrumb {
+	// Find the nearest ancestor with rel="up" links by walking up the path.
+	matchedPath := path
+	var tailSegments []string
+	for {
+		upLinks := LinksFor(matchedPath, "up")
+		if len(upLinks) > 0 {
+			break
+		}
+		// Strip the last segment and try the parent path.
+		idx := strings.LastIndex(matchedPath, "/")
+		if idx <= 0 {
+			// Reached root with no match.
+			return nil
+		}
+		tailSegments = append([]string{matchedPath[idx+1:]}, tailSegments...)
+		matchedPath = matchedPath[:idx]
+	}
+
+	// Walk the rel="up" chain from the matched path.
 	var crumbs []Breadcrumb
 	visited := map[string]bool{}
-	current := path
+	current := matchedPath
 
 	for !visited[current] {
 		visited[current] = true
@@ -249,17 +275,81 @@ func BreadcrumbsFromLinks(path string) []Breadcrumb {
 		current = parent.Href
 	}
 
-	// Add home at the start
-	if len(crumbs) > 0 {
-		crumbs = append([]Breadcrumb{{Label: BreadcrumbLabelHome, Href: "/"}}, crumbs...)
+	// Add home at the start.
+	crumbs = append([]Breadcrumb{{Label: BreadcrumbLabelHome, Href: "/"}}, crumbs...)
+
+	// Add the matched path itself as a breadcrumb (it has rel="up" links,
+	// so it is a known page).
+	crumbs = append(crumbs, Breadcrumb{
+		Label: TitleFromPath(matchedPath),
+		Href:  matchedPath,
+	})
+
+	// Add intermediate tail segments (derived from path walk-up).
+	built := matchedPath
+	for i, seg := range tailSegments {
+		built += "/" + seg
+		href := built
+		if i == len(tailSegments)-1 {
+			href = "" // terminal segment has no href
+		}
+		crumbs = append(crumbs, Breadcrumb{Label: TitleFromPath("/" + seg), Href: href})
 	}
 
-	// Add current page (no href = current page, not a link)
-	if len(crumbs) > 0 {
-		crumbs = append(crumbs, Breadcrumb{Label: TitleFromPath(path)})
+	// If no tail segments were added, the matched path IS the original path,
+	// so set the last crumb's Href to empty (terminal).
+	if len(tailSegments) == 0 {
+		crumbs[len(crumbs)-1].Href = ""
 	}
 
 	return crumbs
+}
+
+// ResolveFromMaskWithPath combines bitmask-resolved breadcrumbs with
+// path-derived crumbs (using the walk-up behavior of BreadcrumbsFromLinks),
+// deduplicating by base path (query parameters stripped for comparison). The
+// from parameter is forwarded as a ?from= query parameter on intermediate path
+// crumb links. Returns nil if path produces no breadcrumbs.
+func ResolveFromMaskWithPath(mask uint64, path string, from string) []Breadcrumb {
+	maskCrumbs := ResolveFromMask(mask)
+	pathCrumbs := BreadcrumbsFromLinks(path)
+	if pathCrumbs == nil {
+		// Fall back to path-based breadcrumbs.
+		pathCrumbs = BreadcrumbsFromPath(path, nil)
+	}
+
+	// Build a set of base paths from mask crumbs for deduplication.
+	seen := make(map[string]bool, len(maskCrumbs))
+	for _, c := range maskCrumbs {
+		seen[basePath(c.Href)] = true
+	}
+
+	// Start with mask crumbs, then append path crumbs that aren't duplicates.
+	merged := make([]Breadcrumb, len(maskCrumbs))
+	copy(merged, maskCrumbs)
+
+	for _, c := range pathCrumbs {
+		bp := basePath(c.Href)
+		if seen[bp] {
+			continue
+		}
+		seen[bp] = true
+		// Forward the from param on intermediate links.
+		if c.Href != "" && from != "" {
+			c.Href = FromNav(c.Href, from)
+		}
+		merged = append(merged, c)
+	}
+
+	return merged
+}
+
+// basePath strips query parameters from a URL path for deduplication.
+func basePath(href string) string {
+	if idx := strings.IndexByte(href, '?'); idx >= 0 {
+		return href[:idx]
+	}
+	return href
 }
 
 // LoadStoredLink adds a single link relation from an external source (e.g., a

--- a/links_test.go
+++ b/links_test.go
@@ -441,6 +441,149 @@ func TestBreadcrumbsFromLinks_IncludesHomeAndCurrent(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// BreadcrumbsFromLinks — path walk-up (#13)
+// ---------------------------------------------------------------------------
+
+func TestBreadcrumbsFromLinks_WalkUpOneSegment(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/groups", "Groups"),
+	)
+
+	crumbs := BreadcrumbsFromLinks("/admin/groups/new")
+	require.NotNil(t, crumbs)
+	// [Home, Admin, Groups, New]
+	require.Len(t, crumbs, 4)
+	assert.Equal(t, BreadcrumbLabelHome, crumbs[0].Label)
+	assert.Equal(t, "/", crumbs[0].Href)
+	assert.Equal(t, "Admin", crumbs[1].Label)
+	assert.Equal(t, "/admin", crumbs[1].Href)
+	assert.Equal(t, "Groups", crumbs[2].Label)
+	assert.Equal(t, "/admin/groups", crumbs[2].Href)
+	assert.Equal(t, "New", crumbs[3].Label)
+	assert.Empty(t, crumbs[3].Href, "terminal segment should have no href")
+}
+
+func TestBreadcrumbsFromLinks_WalkUpNumericSegment(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/groups", "Groups"),
+	)
+
+	crumbs := BreadcrumbsFromLinks("/admin/groups/1")
+	require.NotNil(t, crumbs)
+	// [Home, Admin, Groups, 1]
+	require.Len(t, crumbs, 4)
+	assert.Equal(t, "Groups", crumbs[2].Label)
+	assert.Equal(t, "/admin/groups", crumbs[2].Href)
+	assert.Equal(t, "1", crumbs[3].Label)
+	assert.Empty(t, crumbs[3].Href)
+}
+
+func TestBreadcrumbsFromLinks_WalkUpMultipleSegments(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/groups", "Groups"),
+	)
+
+	crumbs := BreadcrumbsFromLinks("/admin/groups/1/edit")
+	require.NotNil(t, crumbs)
+	// [Home, Admin, Groups, 1, Edit]
+	require.Len(t, crumbs, 5)
+	assert.Equal(t, "Groups", crumbs[2].Label)
+	assert.Equal(t, "/admin/groups", crumbs[2].Href)
+	assert.Equal(t, "1", crumbs[3].Label)
+	assert.Equal(t, "/admin/groups/1", crumbs[3].Href)
+	assert.Equal(t, "Edit", crumbs[4].Label)
+	assert.Empty(t, crumbs[4].Href)
+}
+
+func TestBreadcrumbsFromLinks_WalkUpNoAncestorReturnsNil(t *testing.T) {
+	resetLinks(t)
+
+	crumbs := BreadcrumbsFromLinks("/totally/unknown/path")
+	assert.Nil(t, crumbs)
+}
+
+// ---------------------------------------------------------------------------
+// ResolveFromMaskWithPath (#14)
+// ---------------------------------------------------------------------------
+
+func TestResolveFromMaskWithPath_CombinesMaskAndPath(t *testing.T) {
+	resetLinks(t)
+
+	RegisterFrom(FromDashboard, Breadcrumb{Label: "Dashboard", Href: "/dashboard"})
+	Hub("/admin", "Admin",
+		Rel("/admin/groups", "Groups"),
+	)
+
+	crumbs := ResolveFromMaskWithPath(FromHome|FromDashboard, "/admin/groups", "3")
+	require.NotNil(t, crumbs)
+	// Mask crumbs: [Home, Dashboard]
+	// Path crumbs: [Home, Admin, Groups] — Home is deduplicated
+	// Result: [Home, Dashboard, Admin, Groups]
+	require.Len(t, crumbs, 4)
+	assert.Equal(t, "Home", crumbs[0].Label)
+	assert.Equal(t, "Dashboard", crumbs[1].Label)
+	assert.Equal(t, "Admin", crumbs[2].Label)
+	assert.Contains(t, crumbs[2].Href, "from=3", "intermediate crumbs should have from param")
+	assert.Equal(t, "Groups", crumbs[3].Label)
+	assert.Empty(t, crumbs[3].Href, "terminal crumb should have no href")
+}
+
+func TestResolveFromMaskWithPath_DeduplicatesByBasePath(t *testing.T) {
+	resetLinks(t)
+
+	RegisterFrom(FromDashboard, Breadcrumb{Label: "Dashboard", Href: "/dashboard?tab=overview"})
+	Hub("/dashboard", "Dashboard",
+		Rel("/dashboard/settings", "Settings"),
+	)
+
+	crumbs := ResolveFromMaskWithPath(FromHome|FromDashboard, "/dashboard/settings", "")
+	// Mask: [Home, Dashboard (with query)]
+	// Path: [Home, Dashboard, Settings] — Home and Dashboard deduplicated by base path
+	// Result: [Home, Dashboard (with query), Settings]
+	require.Len(t, crumbs, 3)
+	assert.Equal(t, "Home", crumbs[0].Label)
+	assert.Equal(t, "Dashboard", crumbs[1].Label)
+	assert.Equal(t, "/dashboard?tab=overview", crumbs[1].Href, "mask crumb should keep its query params")
+	assert.Equal(t, "Settings", crumbs[2].Label)
+}
+
+func TestResolveFromMaskWithPath_FallsBackToPathBreadcrumbs(t *testing.T) {
+	resetLinks(t)
+
+	// No links registered — should fall back to BreadcrumbsFromPath
+	crumbs := ResolveFromMaskWithPath(FromHome, "/users/42/edit", "")
+	require.NotNil(t, crumbs)
+	// Mask: [Home]
+	// Fallback path: [Home, users, 42, edit] — Home deduplicated
+	require.Len(t, crumbs, 4)
+	assert.Equal(t, "Home", crumbs[0].Label)
+	assert.Equal(t, "users", crumbs[1].Label)
+	assert.Equal(t, "42", crumbs[2].Label)
+	assert.Equal(t, "edit", crumbs[3].Label)
+}
+
+func TestResolveFromMaskWithPath_NoFromParam(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/groups", "Groups"),
+	)
+
+	crumbs := ResolveFromMaskWithPath(FromHome, "/admin/groups", "")
+	require.NotNil(t, crumbs)
+	// Should not contain from= in any href
+	for _, c := range crumbs {
+		assert.NotContains(t, c.Href, "from=", "no from param should be appended when from is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // LoadStoredLink
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **BreadcrumbsFromLinks path walk-up (#13):** When the exact path has no `rel="up"` links, the function now strips trailing segments and retries up the hierarchy until a registered path is found. Unregistered segments are appended to the trail, with the terminal segment rendered as plain text.
- **ResolveFromMaskWithPath helper (#14):** New function that combines bitmask-resolved breadcrumbs with path-derived crumbs, deduplicating by base path (query params stripped) and forwarding the `from` parameter on intermediate links.

## Test plan

- Walk-up with one extra segment (`/admin/groups/new` -> `[Home, Admin, Groups, New]`)
- Walk-up with numeric segment (`/admin/groups/1` -> `[Home, Admin, Groups, 1]`)
- Walk-up with multiple extra segments (`/admin/groups/1/edit`)
- Walk-up with no ancestor returns nil
- Existing exact-match behavior unchanged
- Cycle detection still works
- ResolveFromMaskWithPath combines mask and path crumbs with deduplication
- Deduplication by base path strips query params
- Fallback to BreadcrumbsFromPath when no links registered
- From param forwarded on intermediate links, omitted when empty

Fixes #13
Fixes #14