### PR TITLE
Add Dothog Manifesto flavor to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 ![linkwell](https://raw.githubusercontent.com/catgoose/screenshots/main/linkwell/linkwell.png)
 
+> WHERE ARE THE LINKS, KEVIN?
+>
+> -- The PENTAVERB, Dothog Manifesto
+
 A Go library for HATEOAS-style hypermedia controls, link relations ([RFC 8288](https://www.rfc-editor.org/rfc/rfc8288)), and navigation primitives. Designed for server-rendered HTML apps using HTMX, but the data types are framework-agnostic.
 
 ## Why
@@ -110,6 +114,10 @@ import hypermedia "github.com/catgoose/linkwell"
 
 ## Link Registry
 
+> The server sends a representation. The representation contains links and forms. The client follows them. THAT IS THE ENTIRE INTERACTION MODEL.
+>
+> -- The Wisdom of the Uniform Interface, Dothog Manifesto
+
 The link registry maintains an in-memory graph of relationships between pages. Register links at startup (typically in route initialization), then query them at request time.
 
 ### Registering Links
@@ -203,6 +211,10 @@ linkwell.RemoveLink("/projects/42", "/teams/7", "related")
 
 ## Breadcrumbs
 
+> The links are RIGHT THERE. In the HTML. They have been there this whole time.
+>
+> -- The Wisdom of the Uniform Interface, Dothog Manifesto
+
 ### From Link Graph
 
 Walk the `rel="up"` chain from a path to build a breadcrumb trail. Requires links registered via `Hub` or `Link` with `rel="up"`.
@@ -249,7 +261,11 @@ href := linkwell.FromNav("/users/42", c.QueryParam("from"))
 
 ## Controls
 
-A `Control` is a pure-data descriptor for a hypermedia affordance (button, link, action). Templates consume controls to render the appropriate HTML element — the control itself has no rendering logic.
+> Hypertext is the simultaneous presentation of information and controls such that the information BECOMES THE AFFORDANCE through which choices are obtained and actions are selected.
+>
+> -- The Wisdom of the Uniform Interface, Dothog Manifesto
+
+A `Control` is a pure-data descriptor for a hypermedia affordance (button, link, action). Templates consume controls to render the appropriate HTML element -- the control itself has no rendering logic.
 
 ### Factory Functions
 


### PR DESCRIPTION
## Summary
- Add "WHERE ARE THE LINKS, KEVIN?" to intro (linkwell's entire reason to exist)
- Add HATEOAS interaction model quote to Link Registry section
- Add "links are RIGHT THERE" quote to Breadcrumbs section
- Add hypertext/controls definition quote to Controls section
- All technical content unchanged, quotes placed as block quotes between sections