### PR TITLE
feat: add Toast type for notifications

### DIFF
--- a/toast.go
+++ b/toast.go
@@ -1,0 +1,82 @@
+package linkwell
+
+// ToastVariant identifies the severity or intent of a Toast notification.
+// Templates map variants to visual styles (e.g., DaisyUI alert-success).
+type ToastVariant string
+
+const (
+	// ToastSuccess indicates a successful operation.
+	ToastSuccess ToastVariant = "success"
+	// ToastInfo provides neutral informational feedback.
+	ToastInfo ToastVariant = "info"
+	// ToastWarning signals a non-blocking issue that deserves attention.
+	ToastWarning ToastVariant = "warning"
+	// ToastError indicates a failed operation (complement to ErrorContext).
+	ToastError ToastVariant = "error"
+)
+
+// Toast is a pure-data descriptor for a transient notification. It is the
+// success/info/warning complement to ErrorContext: the server decides what
+// feedback to show and the template renders the appropriate alert with optional
+// action controls. Toasts are value types; use the With* methods to derive
+// modified copies.
+type Toast struct {
+	// Message is the user-visible notification text.
+	Message string
+	// Variant determines the visual style (success, info, warning, error).
+	Variant ToastVariant
+	// Controls is an optional set of action affordances rendered with the toast
+	// (e.g., an "Undo" button).
+	Controls []Control
+	// AutoDismiss is the number of seconds before the toast auto-closes.
+	// Zero means the toast is sticky and must be dismissed manually.
+	AutoDismiss int
+	// OOBTarget is the CSS selector for an HTMX OOB swap target. When set,
+	// the toast renders as an out-of-band fragment.
+	OOBTarget string
+	// OOBSwap is the hx-swap-oob strategy (e.g., "afterbegin").
+	OOBSwap string
+}
+
+// SuccessToast creates a Toast with the success variant.
+func SuccessToast(message string) Toast {
+	return Toast{Message: message, Variant: ToastSuccess}
+}
+
+// InfoToast creates a Toast with the info variant.
+func InfoToast(message string) Toast {
+	return Toast{Message: message, Variant: ToastInfo}
+}
+
+// WarningToast creates a Toast with the warning variant.
+func WarningToast(message string) Toast {
+	return Toast{Message: message, Variant: ToastWarning}
+}
+
+// ErrorToast creates a Toast with the error variant.
+func ErrorToast(message string) Toast {
+	return Toast{Message: message, Variant: ToastError}
+}
+
+// WithControls returns a copy of the Toast with the given controls appended to
+// the existing set. The original is not modified.
+func (t Toast) WithControls(controls ...Control) Toast {
+	t.Controls = append(append([]Control(nil), t.Controls...), controls...)
+	return t
+}
+
+// WithAutoDismiss returns a copy of the Toast with the given auto-dismiss
+// duration in seconds. Pass 0 for a sticky toast.
+func (t Toast) WithAutoDismiss(seconds int) Toast {
+	t.AutoDismiss = seconds
+	return t
+}
+
+// WithOOB returns a copy of the Toast configured for HTMX out-of-band swap
+// rendering. Set target to the CSS selector and swap to the hx-swap-oob
+// strategy (e.g., "afterbegin").
+func (t Toast) WithOOB(target, swap string) Toast {
+	t.OOBTarget = target
+	t.OOBSwap = swap
+	return t
+}

--- a/toast_test.go
+++ b/toast_test.go
@@ -1,0 +1,94 @@
+package linkwell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuccessToast(t *testing.T) {
+	toast := SuccessToast("saved")
+
+	require.Equal(t, "saved", toast.Message)
+	require.Equal(t, ToastSuccess, toast.Variant)
+	require.Empty(t, toast.Controls)
+	require.Zero(t, toast.AutoDismiss)
+	require.Empty(t, toast.OOBTarget)
+	require.Empty(t, toast.OOBSwap)
+}
+
+func TestInfoToast(t *testing.T) {
+	toast := InfoToast("processing")
+
+	require.Equal(t, "processing", toast.Message)
+	require.Equal(t, ToastInfo, toast.Variant)
+}
+
+func TestWarningToast(t *testing.T) {
+	toast := WarningToast("rate limit approaching")
+
+	require.Equal(t, "rate limit approaching", toast.Message)
+	require.Equal(t, ToastWarning, toast.Variant)
+}
+
+func TestErrorToast(t *testing.T) {
+	toast := ErrorToast("upload failed")
+
+	require.Equal(t, "upload failed", toast.Message)
+	require.Equal(t, ToastError, toast.Variant)
+}
+
+func TestToast_WithControls(t *testing.T) {
+	original := SuccessToast("user deleted").
+		WithControls(BackButton("Back"))
+
+	updated := original.WithControls(GoHomeButton("Home", "/", "#main"))
+
+	// Original is not mutated.
+	require.Len(t, original.Controls, 1)
+	// Updated has both controls.
+	require.Len(t, updated.Controls, 2)
+	require.Equal(t, ControlKindBack, updated.Controls[0].Kind)
+	require.Equal(t, ControlKindHome, updated.Controls[1].Kind)
+}
+
+func TestToast_WithAutoDismiss(t *testing.T) {
+	original := SuccessToast("saved")
+
+	updated := original.WithAutoDismiss(5)
+
+	// Original is not mutated.
+	require.Zero(t, original.AutoDismiss)
+	// Updated carries the duration.
+	require.Equal(t, 5, updated.AutoDismiss)
+}
+
+func TestToast_WithOOB(t *testing.T) {
+	original := InfoToast("synced")
+
+	updated := original.WithOOB("#toast-container", "afterbegin")
+
+	// Original is not mutated.
+	require.Empty(t, original.OOBTarget)
+	require.Empty(t, original.OOBSwap)
+	// Updated carries OOB fields.
+	require.Equal(t, "#toast-container", updated.OOBTarget)
+	require.Equal(t, "afterbegin", updated.OOBSwap)
+}
+
+func TestToast_FullBuilder(t *testing.T) {
+	toast := SuccessToast("User deleted").
+		WithControls(HTMXAction("Undo", HxPost("/users/42/restore", "#user-table"))).
+		WithAutoDismiss(5).
+		WithOOB("#toast-container", "afterbegin")
+
+	require.Equal(t, "User deleted", toast.Message)
+	require.Equal(t, ToastSuccess, toast.Variant)
+	require.Len(t, toast.Controls, 1)
+	require.Equal(t, "Undo", toast.Controls[0].Label)
+	require.Equal(t, HxMethodPost, toast.Controls[0].HxRequest.Method)
+	require.Equal(t, "/users/42/restore", toast.Controls[0].HxRequest.URL)
+	require.Equal(t, 5, toast.AutoDismiss)
+	require.Equal(t, "#toast-container", toast.OOBTarget)
+	require.Equal(t, "afterbegin", toast.OOBSwap)
+}


### PR DESCRIPTION
## Summary

- Add `Toast` type as the success/info/warning complement to `ErrorContext`, with `ToastVariant` constants (success, info, warning, error)
- Provide factory functions (`SuccessToast`, `InfoToast`, `WarningToast`, `ErrorToast`) and builder methods (`WithControls`, `WithAutoDismiss`, `WithOOB`)
- Follow existing value-type builder pattern from `ErrorContext` and `Control`

Closes #22

## Test plan

- [x] Factory functions produce correct variant and message
- [x] `WithControls` appends without mutating original
- [x] `WithAutoDismiss` sets duration without mutating original
- [x] `WithOOB` sets target/swap without mutating original
- [x] Full builder chain matches issue usage example