### PR TITLE
feat: add TabConfig and TabItem types for in-page tabbed navigation

### DIFF
--- a/tab.go
+++ b/tab.go
@@ -1,0 +1,61 @@
+package linkwell
+
+// TabItem is a server-computed tab entry for in-page tabbed navigation. Active
+// state is determined by the handler (via SetActiveTab), not by client-side
+// JavaScript. Each tab typically maps to an HTMX lazy-loaded content panel.
+type TabItem struct {
+	// Label is the user-visible text for this tab.
+	Label string
+	// Href is the content endpoint loaded when the tab is selected.
+	Href string
+	// Target is the hx-target CSS selector for this tab's content panel.
+	// Overrides TabConfig.Target when set.
+	Target string
+	// Icon is the icon name rendered alongside the label.
+	Icon Icon
+	// Active indicates this tab matches the current page. Set by SetActiveTab
+	// or manually by the handler.
+	Active bool
+	// Disabled renders the tab in a non-interactive state.
+	Disabled bool
+	// Badge is an optional count or status indicator displayed on the tab.
+	Badge string
+	// Swap is the HTMX swap strategy for this tab's content. Defaults to
+	// innerHTML when empty.
+	Swap SwapMode
+}
+
+// TabConfig holds the configuration for an in-page tabbed navigation component.
+// The server decides which tabs exist and which is active — templates consume
+// this to render the tab bar and content panel.
+type TabConfig struct {
+	// ID is a unique identifier for this tab group (e.g., "user-tabs").
+	ID string
+	// Items is the ordered list of tab entries.
+	Items []TabItem
+	// Target is the shared default hx-target CSS selector for all tabs.
+	// Individual TabItem.Target values override this.
+	Target string
+}
+
+// NewTabConfig creates a TabConfig with the given ID, shared target selector,
+// and tab items. Items with an empty Target inherit the shared target at
+// render time.
+func NewTabConfig(id, target string, items ...TabItem) TabConfig {
+	return TabConfig{
+		ID:     id,
+		Items:  items,
+		Target: target,
+	}
+}
+
+// SetActiveTab sets the Active flag on tab items using exact path matching.
+// Returns a new slice; the input is not modified.
+func SetActiveTab(tabs []TabItem, currentPath string) []TabItem {
+	result := make([]TabItem, len(tabs))
+	for i, tab := range tabs {
+		tab.Active = tab.Href == currentPath
+		result[i] = tab
+	}
+	return result
+}

--- a/tab_test.go
+++ b/tab_test.go
@@ -1,0 +1,139 @@
+package linkwell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// NewTabConfig
+// ---------------------------------------------------------------------------
+
+func TestNewTabConfig_SetsFields(t *testing.T) {
+	tabs := NewTabConfig("user-tabs", "#tab-content",
+		TabItem{Label: "Overview", Href: "/users/42/overview"},
+		TabItem{Label: "Activity", Href: "/users/42/activity"},
+	)
+	require.Equal(t, "user-tabs", tabs.ID)
+	require.Equal(t, "#tab-content", tabs.Target)
+	require.Len(t, tabs.Items, 2)
+	require.Equal(t, "Overview", tabs.Items[0].Label)
+	require.Equal(t, "Activity", tabs.Items[1].Label)
+}
+
+func TestNewTabConfig_NoItems(t *testing.T) {
+	tabs := NewTabConfig("empty", "#panel")
+	require.Equal(t, "empty", tabs.ID)
+	require.Equal(t, "#panel", tabs.Target)
+	require.Empty(t, tabs.Items)
+}
+
+// ---------------------------------------------------------------------------
+// SetActiveTab
+// ---------------------------------------------------------------------------
+
+func TestSetActiveTab_ExactMatch(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "Overview", Href: "/users/42/overview"},
+		{Label: "Activity", Href: "/users/42/activity"},
+		{Label: "Settings", Href: "/users/42/settings"},
+	}
+	result := SetActiveTab(tabs, "/users/42/activity")
+	require.False(t, result[0].Active, "Overview should not be active")
+	require.True(t, result[1].Active, "Activity should be active")
+	require.False(t, result[2].Active, "Settings should not be active")
+}
+
+func TestSetActiveTab_NoMatch(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "Overview", Href: "/users/42/overview"},
+		{Label: "Activity", Href: "/users/42/activity"},
+	}
+	result := SetActiveTab(tabs, "/other")
+	for _, tab := range result {
+		require.False(t, tab.Active, "%s should not be active", tab.Label)
+	}
+}
+
+func TestSetActiveTab_DoesNotMutateOriginal(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "Overview", Href: "/users/42/overview"},
+	}
+	result := SetActiveTab(tabs, "/users/42/overview")
+	require.True(t, result[0].Active)
+	require.False(t, tabs[0].Active, "original slice must not be mutated")
+}
+
+func TestSetActiveTab_EmptySlice(t *testing.T) {
+	result := SetActiveTab(nil, "/anything")
+	require.Empty(t, result)
+}
+
+func TestSetActiveTab_PreservesOtherFields(t *testing.T) {
+	tabs := []TabItem{
+		{
+			Label:    "Overview",
+			Href:     "/users/42/overview",
+			Target:   "#custom-panel",
+			Icon:     IconHome,
+			Disabled: true,
+			Badge:    "3",
+			Swap:     SwapOuterHTML,
+		},
+	}
+	result := SetActiveTab(tabs, "/users/42/overview")
+	require.True(t, result[0].Active)
+	require.Equal(t, "#custom-panel", result[0].Target)
+	require.Equal(t, IconHome, result[0].Icon)
+	require.True(t, result[0].Disabled)
+	require.Equal(t, "3", result[0].Badge)
+	require.Equal(t, SwapOuterHTML, result[0].Swap)
+}
+
+// ---------------------------------------------------------------------------
+// TabItem fields
+// ---------------------------------------------------------------------------
+
+func TestTabItem_ZeroValue(t *testing.T) {
+	var tab TabItem
+	require.Empty(t, tab.Label)
+	require.Empty(t, tab.Href)
+	require.Empty(t, tab.Target)
+	require.Empty(t, tab.Icon)
+	require.False(t, tab.Active)
+	require.False(t, tab.Disabled)
+	require.Empty(t, tab.Badge)
+	require.Empty(t, string(tab.Swap))
+}
+
+func TestTabConfig_ItemTargetOverridesDefault(t *testing.T) {
+	tabs := NewTabConfig("tabs", "#default-panel",
+		TabItem{Label: "A", Href: "/a"},
+		TabItem{Label: "B", Href: "/b", Target: "#custom"},
+	)
+	require.Equal(t, "#default-panel", tabs.Target)
+	require.Empty(t, tabs.Items[0].Target, "item A uses shared default")
+	require.Equal(t, "#custom", tabs.Items[1].Target, "item B has its own target")
+}
+
+// ---------------------------------------------------------------------------
+// Integration: NewTabConfig + SetActiveTab
+// ---------------------------------------------------------------------------
+
+func TestNewTabConfig_WithSetActiveTab(t *testing.T) {
+	tabs := NewTabConfig("user-tabs", "#tab-content",
+		TabItem{Label: "Overview", Href: "/users/42/overview", Icon: "user"},
+		TabItem{Label: "Activity", Href: "/users/42/activity", Icon: "clock"},
+		TabItem{Label: "Settings", Href: "/users/42/settings", Icon: "cog"},
+	)
+	tabs.Items = SetActiveTab(tabs.Items, "/users/42/activity")
+
+	require.Equal(t, "user-tabs", tabs.ID)
+	require.Equal(t, "#tab-content", tabs.Target)
+	require.Len(t, tabs.Items, 3)
+	require.False(t, tabs.Items[0].Active)
+	require.True(t, tabs.Items[1].Active)
+	require.False(t, tabs.Items[2].Active)
+	require.Equal(t, Icon("clock"), tabs.Items[1].Icon)
+}


### PR DESCRIPTION
## Summary

- Adds `TabItem` and `TabConfig` types for server-driven in-page tabbed navigation with HTMX lazy-load semantics
- Adds `NewTabConfig` factory and `SetActiveTab` exact-path matching helper
- Follows existing `NavItem`/`NavConfig` patterns — pure data, no rendering logic, no external dependencies

## Test plan

- [x] `TestNewTabConfig_SetsFields` — verifies factory populates ID, Target, Items
- [x] `TestNewTabConfig_NoItems` — empty tab config
- [x] `TestSetActiveTab_ExactMatch` — correct tab activated by path
- [x] `TestSetActiveTab_NoMatch` — no tabs active when path doesn't match
- [x] `TestSetActiveTab_DoesNotMutateOriginal` — input slice immutability
- [x] `TestSetActiveTab_PreservesOtherFields` — all fields survive activation
- [x] `TestNewTabConfig_WithSetActiveTab` — end-to-end integration test matching issue usage example

Closes #21