### PR TITLE
feat: Sitemap generation from link graph

### DIFF
--- a/sitemap.go
+++ b/sitemap.go
@@ -1,0 +1,110 @@
+package linkwell
+
+import "sort"
+
+// SitemapEntry represents a single page in the site hierarchy, derived from the
+// link registry. Each entry captures the page's path, title, parent (via
+// rel="up"), children (hub spokes), and optional ring group membership.
+type SitemapEntry struct {
+	// Path is the URL path of the page.
+	Path string
+	// Title is a human-readable label for the page.
+	Title string
+	// Parent is the rel="up" parent path, empty for root entries.
+	Parent string
+	// Children holds spoke paths when this entry is a hub center.
+	Children []string
+	// Group is the ring group name, if any.
+	Group string
+}
+
+// Sitemap derives a structured sitemap from the link registry. It collects all
+// registered paths, resolves parent relationships from rel="up" links, populates
+// children from hub registrations, and captures ring group membership. Entries
+// are sorted alphabetically by path.
+func Sitemap() []SitemapEntry {
+	all := AllLinks()
+	hubs := Hubs()
+
+	// Build a set of hub centers for quick lookup, and map center -> spoke paths.
+	hubChildren := make(map[string][]string, len(hubs))
+	for _, h := range hubs {
+		children := make([]string, 0, len(h.Spokes))
+		for _, s := range h.Spokes {
+			children = append(children, s.Href)
+		}
+		hubChildren[h.Path] = children
+	}
+
+	// Build hub title lookup.
+	hubTitles := make(map[string]string, len(hubs))
+	for _, h := range hubs {
+		hubTitles[h.Path] = h.Title
+	}
+
+	// Collect all unique paths.
+	pathSet := make(map[string]bool, len(all))
+	for p := range all {
+		pathSet[p] = true
+	}
+
+	paths := make([]string, 0, len(pathSet))
+	for p := range pathSet {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	entries := make([]SitemapEntry, 0, len(paths))
+	for _, p := range paths {
+		links := all[p]
+
+		entry := SitemapEntry{
+			Path: p,
+		}
+
+		// Resolve title: prefer hub title, then derive from path.
+		if t, ok := hubTitles[p]; ok {
+			entry.Title = t
+		} else {
+			entry.Title = TitleFromPath(p)
+		}
+
+		// Find parent from rel="up" links.
+		for _, l := range links {
+			if l.Rel == RelUp {
+				entry.Parent = l.Href
+				break
+			}
+		}
+
+		// Populate children from hub spokes.
+		if children, ok := hubChildren[p]; ok {
+			entry.Children = children
+		}
+
+		// Capture group from any link that has one set.
+		for _, l := range links {
+			if l.Group != "" {
+				entry.Group = l.Group
+				break
+			}
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+// SitemapRoots returns only sitemap entries that have no parent (empty Parent
+// field). These are the top-level pages in the site hierarchy.
+func SitemapRoots() []SitemapEntry {
+	all := Sitemap()
+	var roots []SitemapEntry
+	for _, e := range all {
+		if e.Parent == "" {
+			roots = append(roots, e)
+		}
+	}
+	return roots
+}

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -1,0 +1,212 @@
+package linkwell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Sitemap
+// ---------------------------------------------------------------------------
+
+func TestSitemap_Empty(t *testing.T) {
+	resetLinks(t)
+
+	entries := Sitemap()
+	assert.Empty(t, entries)
+}
+
+func TestSitemap_HubWithSpokes(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/users", "Users"),
+		Rel("/admin/groups", "Groups"),
+	)
+
+	entries := Sitemap()
+	require.NotEmpty(t, entries)
+
+	// Build a lookup by path for easier assertions.
+	byPath := make(map[string]SitemapEntry, len(entries))
+	for _, e := range entries {
+		byPath[e.Path] = e
+	}
+
+	// Hub center should have children and no parent.
+	admin := byPath["/admin"]
+	assert.Equal(t, "Admin", admin.Title)
+	assert.Empty(t, admin.Parent)
+	assert.ElementsMatch(t, []string{"/admin/groups", "/admin/users"}, admin.Children)
+
+	// Spokes should have parent pointing to hub center.
+	users := byPath["/admin/users"]
+	assert.Equal(t, "Users", users.Title)
+	assert.Equal(t, "/admin", users.Parent)
+	assert.Nil(t, users.Children)
+
+	groups := byPath["/admin/groups"]
+	assert.Equal(t, "Groups", groups.Title)
+	assert.Equal(t, "/admin", groups.Parent)
+	assert.Nil(t, groups.Children)
+}
+
+func TestSitemap_RingGroup(t *testing.T) {
+	resetLinks(t)
+
+	Ring("reports",
+		Rel("/reports/daily", "Daily"),
+		Rel("/reports/weekly", "Weekly"),
+		Rel("/reports/monthly", "Monthly"),
+	)
+
+	entries := Sitemap()
+	require.NotEmpty(t, entries)
+
+	for _, e := range entries {
+		assert.Equal(t, "reports", e.Group, "all ring members should have group set")
+		assert.Empty(t, e.Parent, "ring members have no parent")
+		assert.Nil(t, e.Children, "ring members are not hub centers")
+	}
+}
+
+func TestSitemap_SortedByPath(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/z-section", "Z Section", Rel("/z-section/page", "Page"))
+	Hub("/a-section", "A Section", Rel("/a-section/page", "Page"))
+
+	entries := Sitemap()
+	require.True(t, len(entries) >= 4)
+
+	for i := 1; i < len(entries); i++ {
+		assert.True(t, entries[i-1].Path <= entries[i].Path,
+			"entries must be sorted by path: %s > %s", entries[i-1].Path, entries[i].Path)
+	}
+}
+
+func TestSitemap_MixedTopology(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/users", "Users"),
+	)
+	Ring("tools",
+		Rel("/tools/import", "Import"),
+		Rel("/tools/export", "Export"),
+	)
+	Link("/about", RelRelated, "/contact", "Contact")
+
+	entries := Sitemap()
+	require.NotEmpty(t, entries)
+
+	byPath := make(map[string]SitemapEntry, len(entries))
+	for _, e := range entries {
+		byPath[e.Path] = e
+	}
+
+	// Hub center
+	assert.NotEmpty(t, byPath["/admin"].Children)
+	// Hub spoke
+	assert.Equal(t, "/admin", byPath["/admin/users"].Parent)
+	// Ring members
+	assert.Equal(t, "tools", byPath["/tools/import"].Group)
+	assert.Equal(t, "tools", byPath["/tools/export"].Group)
+	// Plain related links
+	assert.Contains(t, byPath, "/about")
+	assert.Contains(t, byPath, "/contact")
+}
+
+func TestSitemap_TitleDerivedFromPath(t *testing.T) {
+	resetLinks(t)
+
+	Link("/demo/my-feature", RelUp, "/demo", "Demo")
+
+	entries := Sitemap()
+	byPath := make(map[string]SitemapEntry, len(entries))
+	for _, e := range entries {
+		byPath[e.Path] = e
+	}
+
+	assert.Equal(t, "My Feature", byPath["/demo/my-feature"].Title)
+}
+
+func TestSitemap_HubTitlePreferred(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/dashboard", "Main Dashboard",
+		Rel("/dashboard/stats", "Statistics"),
+	)
+
+	entries := Sitemap()
+	byPath := make(map[string]SitemapEntry, len(entries))
+	for _, e := range entries {
+		byPath[e.Path] = e
+	}
+
+	assert.Equal(t, "Main Dashboard", byPath["/dashboard"].Title,
+		"hub title should be preferred over TitleFromPath")
+}
+
+// ---------------------------------------------------------------------------
+// SitemapRoots
+// ---------------------------------------------------------------------------
+
+func TestSitemapRoots_Empty(t *testing.T) {
+	resetLinks(t)
+
+	roots := SitemapRoots()
+	assert.Empty(t, roots)
+}
+
+func TestSitemapRoots_OnlyRoots(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/users", "Users"),
+		Rel("/admin/groups", "Groups"),
+	)
+	Ring("tools",
+		Rel("/tools/import", "Import"),
+		Rel("/tools/export", "Export"),
+	)
+
+	roots := SitemapRoots()
+	require.NotEmpty(t, roots)
+
+	for _, r := range roots {
+		assert.Empty(t, r.Parent, "root entries must have no parent")
+	}
+
+	// Hub center is a root; spokes are not.
+	rootPaths := make(map[string]bool, len(roots))
+	for _, r := range roots {
+		rootPaths[r.Path] = true
+	}
+	assert.True(t, rootPaths["/admin"], "hub center should be a root")
+	assert.False(t, rootPaths["/admin/users"], "spoke should not be a root")
+	assert.False(t, rootPaths["/admin/groups"], "spoke should not be a root")
+	// Ring members have no parent, so they are roots.
+	assert.True(t, rootPaths["/tools/import"], "ring member should be a root")
+	assert.True(t, rootPaths["/tools/export"], "ring member should be a root")
+}
+
+func TestSitemapRoots_SortedByPath(t *testing.T) {
+	resetLinks(t)
+
+	Ring("nav",
+		Rel("/z-page", "Z"),
+		Rel("/a-page", "A"),
+		Rel("/m-page", "M"),
+	)
+
+	roots := SitemapRoots()
+	require.True(t, len(roots) >= 3)
+
+	for i := 1; i < len(roots); i++ {
+		assert.True(t, roots[i-1].Path <= roots[i].Path,
+			"roots must be sorted by path: %s > %s", roots[i-1].Path, roots[i].Path)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SitemapEntry` struct with Path, Title, Parent, Children, and Group fields
- Adds `Sitemap()` function that derives entries from the link registry (hubs, rings, plain links)
- Adds `SitemapRoots()` function that returns only entries with no parent
- Comprehensive test coverage for empty state, hub/spoke, ring groups, mixed topologies, sorting, and title resolution

Closes #27