### PR TITLE
feat: link graph validation for tests and diagnostics

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,127 @@
+package linkwell
+
+// LinkIssue describes a structural problem detected in the link registry.
+type LinkIssue struct {
+	// Path is the registry path where the issue was detected.
+	Path string
+	// Message is a human-readable description of the problem.
+	Message string
+	// Kind classifies the issue for programmatic filtering.
+	// Values: "orphan", "broken_up", "dead_spoke", "unregistered_route", "missing_route".
+	Kind string
+}
+
+// ValidateGraph checks the link registry for structural issues and returns a
+// slice of problems found. An empty slice means no issues were detected.
+//
+// Detected issues:
+//   - orphan: a registered path has no inbound links from any other path.
+//   - broken_up: a rel="up" link targets a path that has no registered links.
+//   - dead_spoke: a hub spoke path has no links registered (empty link set).
+func ValidateGraph() []LinkIssue {
+	all := AllLinks()
+	hubs := Hubs()
+
+	var issues []LinkIssue
+
+	// Build set of all paths that are link targets (inbound links).
+	inbound := make(map[string]bool)
+	for _, links := range all {
+		for _, l := range links {
+			inbound[l.Href] = true
+		}
+	}
+
+	// Check each registered path for issues.
+	for path := range all {
+		// Orphan: no other path links to this one.
+		if !inbound[path] {
+			issues = append(issues, LinkIssue{
+				Path:    path,
+				Message: "no inbound links from any other registered path",
+				Kind:    "orphan",
+			})
+		}
+
+		// Broken rel="up": target path is not registered.
+		for _, l := range all[path] {
+			if l.Rel == RelUp {
+				if _, ok := all[l.Href]; !ok {
+					issues = append(issues, LinkIssue{
+						Path:    path,
+						Message: "rel=\"up\" target " + l.Href + " is not registered",
+						Kind:    "broken_up",
+					})
+				}
+			}
+		}
+	}
+
+	// Dead hub spokes: spoke path has no links registered.
+	for _, hub := range hubs {
+		for _, spoke := range hub.Spokes {
+			if _, ok := all[spoke.Href]; !ok {
+				issues = append(issues, LinkIssue{
+					Path:    spoke.Href,
+					Message: "hub spoke for " + hub.Title + " (" + hub.Path + ") has no registered links",
+					Kind:    "dead_spoke",
+				})
+			}
+		}
+	}
+
+	return issues
+}
+
+// ValidateAgainstRoutes checks that all registered link paths exist in the
+// provided route set, and that all routes have a link graph presence. Returns
+// issues for any mismatches.
+//
+// Detected issues:
+//   - unregistered_route: a path in the link registry has no matching route.
+//   - missing_route: a route has no presence in the link registry (neither as a
+//     source nor as a target).
+func ValidateAgainstRoutes(routes []string) []LinkIssue {
+	all := AllLinks()
+
+	var issues []LinkIssue
+
+	// Build route set for fast lookup.
+	routeSet := make(map[string]bool, len(routes))
+	for _, r := range routes {
+		routeSet[r] = true
+	}
+
+	// Build set of all paths present in the link graph (sources + targets).
+	graphPaths := make(map[string]bool)
+	for path, links := range all {
+		graphPaths[path] = true
+		for _, l := range links {
+			graphPaths[l.Href] = true
+		}
+	}
+
+	// Registered paths with no matching route.
+	for path := range all {
+		if !routeSet[path] {
+			issues = append(issues, LinkIssue{
+				Path:    path,
+				Message: "registered path has no matching route",
+				Kind:    "unregistered_route",
+			})
+		}
+	}
+
+	// Routes with no link graph presence.
+	for _, route := range routes {
+		if !graphPaths[route] {
+			issues = append(issues, LinkIssue{
+				Path:    route,
+				Message: "route has no link graph presence",
+				Kind:    "missing_route",
+			})
+		}
+	}
+
+	return issues
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,243 @@
+package linkwell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ValidateGraph
+// ---------------------------------------------------------------------------
+
+func TestValidateGraph_Clean(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/users", "Users"),
+		Rel("/admin/groups", "Groups"),
+	)
+
+	issues := ValidateGraph()
+	assert.Empty(t, issues, "well-formed hub should produce no issues")
+}
+
+func TestValidateGraph_Orphan(t *testing.T) {
+	resetLinks(t)
+
+	// /orphan links out but nothing links to it
+	Link("/orphan", "up", "/parent", "Parent")
+	// Register /parent so it's not flagged as broken_up target
+	Link("/parent", "related", "/other", "Other")
+
+	issues := ValidateGraph()
+	var orphans []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "orphan" && i.Path == "/orphan" {
+			orphans = append(orphans, i)
+		}
+	}
+	require.Len(t, orphans, 1)
+	assert.Contains(t, orphans[0].Message, "no inbound links")
+}
+
+func TestValidateGraph_BrokenUp(t *testing.T) {
+	resetLinks(t)
+
+	// /child has rel="up" pointing to /missing which is not registered
+	linksMu.Lock()
+	linksMap["/child"] = []LinkRelation{
+		{Rel: RelUp, Href: "/missing", Title: "Missing"},
+	}
+	linksMu.Unlock()
+
+	issues := ValidateGraph()
+	var broken []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "broken_up" {
+			broken = append(broken, i)
+		}
+	}
+	require.Len(t, broken, 1)
+	assert.Equal(t, "/child", broken[0].Path)
+	assert.Contains(t, broken[0].Message, "/missing")
+}
+
+func TestValidateGraph_DeadSpoke(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/hub", "Hub", Rel("/spoke", "Spoke"))
+
+	// Remove all links from /spoke to simulate a dead spoke
+	linksMu.Lock()
+	delete(linksMap, "/spoke")
+	linksMu.Unlock()
+
+	issues := ValidateGraph()
+	var deadSpokes []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "dead_spoke" {
+			deadSpokes = append(deadSpokes, i)
+		}
+	}
+	require.Len(t, deadSpokes, 1)
+	assert.Equal(t, "/spoke", deadSpokes[0].Path)
+	assert.Contains(t, deadSpokes[0].Message, "Hub")
+}
+
+func TestValidateGraph_EmptyRegistry(t *testing.T) {
+	resetLinks(t)
+
+	issues := ValidateGraph()
+	assert.Empty(t, issues, "empty registry should produce no issues")
+}
+
+func TestValidateGraph_Ring_NoOrphans(t *testing.T) {
+	resetLinks(t)
+
+	Ring("group",
+		Rel("/a", "A"),
+		Rel("/b", "B"),
+		Rel("/c", "C"),
+	)
+
+	issues := ValidateGraph()
+	var orphans []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "orphan" {
+			orphans = append(orphans, i)
+		}
+	}
+	assert.Empty(t, orphans, "ring members should all have inbound links")
+}
+
+func TestValidateGraph_MultipleIssues(t *testing.T) {
+	resetLinks(t)
+
+	// Orphan with broken up chain
+	linksMu.Lock()
+	linksMap["/orphan-broken"] = []LinkRelation{
+		{Rel: RelUp, Href: "/nonexistent", Title: "Gone"},
+	}
+	linksMu.Unlock()
+
+	issues := ValidateGraph()
+	require.True(t, len(issues) >= 2, "expected at least orphan + broken_up issues")
+
+	kinds := make(map[string]bool)
+	for _, i := range issues {
+		kinds[i.Kind] = true
+	}
+	assert.True(t, kinds["orphan"])
+	assert.True(t, kinds["broken_up"])
+}
+
+// ---------------------------------------------------------------------------
+// ValidateAgainstRoutes
+// ---------------------------------------------------------------------------
+
+func TestValidateAgainstRoutes_AllMatch(t *testing.T) {
+	resetLinks(t)
+
+	Hub("/admin", "Admin",
+		Rel("/admin/users", "Users"),
+	)
+
+	routes := []string{"/admin", "/admin/users"}
+	issues := ValidateAgainstRoutes(routes)
+	assert.Empty(t, issues, "all paths match routes — no issues expected")
+}
+
+func TestValidateAgainstRoutes_UnregisteredRoute(t *testing.T) {
+	resetLinks(t)
+
+	// Register a path that won't be in the route list
+	linksMu.Lock()
+	linksMap["/phantom"] = []LinkRelation{
+		{Rel: RelRelated, Href: "/other", Title: "Other"},
+	}
+	linksMu.Unlock()
+
+	routes := []string{"/other"}
+	issues := ValidateAgainstRoutes(routes)
+
+	var unregistered []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "unregistered_route" {
+			unregistered = append(unregistered, i)
+		}
+	}
+	require.Len(t, unregistered, 1)
+	assert.Equal(t, "/phantom", unregistered[0].Path)
+	assert.Contains(t, unregistered[0].Message, "no matching route")
+}
+
+func TestValidateAgainstRoutes_MissingRoute(t *testing.T) {
+	resetLinks(t)
+
+	Link("/a", "related", "/b", "B")
+
+	routes := []string{"/a", "/b", "/c"}
+	issues := ValidateAgainstRoutes(routes)
+
+	var missing []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "missing_route" {
+			missing = append(missing, i)
+		}
+	}
+	require.Len(t, missing, 1)
+	assert.Equal(t, "/c", missing[0].Path)
+	assert.Contains(t, missing[0].Message, "no link graph presence")
+}
+
+func TestValidateAgainstRoutes_EmptyRoutes(t *testing.T) {
+	resetLinks(t)
+
+	Link("/a", "related", "/b", "B")
+
+	issues := ValidateAgainstRoutes(nil)
+	var unregistered []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "unregistered_route" {
+			unregistered = append(unregistered, i)
+		}
+	}
+	// Both /a and /b are registered as sources
+	assert.True(t, len(unregistered) >= 1, "registered paths with no routes should be flagged")
+}
+
+func TestValidateAgainstRoutes_EmptyRegistry(t *testing.T) {
+	resetLinks(t)
+
+	routes := []string{"/a", "/b"}
+	issues := ValidateAgainstRoutes(routes)
+
+	var missing []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "missing_route" {
+			missing = append(missing, i)
+		}
+	}
+	assert.Len(t, missing, 2, "all routes should be flagged as missing from empty registry")
+}
+
+func TestValidateAgainstRoutes_TargetOnlyPathNotFlagged(t *testing.T) {
+	resetLinks(t)
+
+	// /target is only a link target, not a source — but it should still
+	// count as present in the graph for route matching purposes.
+	Link("/source", "up", "/target", "Target")
+
+	routes := []string{"/source", "/target"}
+	issues := ValidateAgainstRoutes(routes)
+
+	var missing []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "missing_route" {
+			missing = append(missing, i)
+		}
+	}
+	assert.Empty(t, missing, "target-only paths should count as graph presence")
+}


### PR DESCRIPTION
## Summary

- Adds `ValidateGraph()` to detect orphan paths, broken `rel="up"` chains, and dead hub spokes in the link registry
- Adds `ValidateAgainstRoutes(routes []string)` to check that registered paths match application routes and vice versa
- Introduces `LinkIssue` struct with `Path`, `Message`, and `Kind` fields for programmatic filtering of detected issues

## Test plan

- [x] `ValidateGraph` returns no issues for well-formed hub and ring topologies
- [x] Detects orphan paths with no inbound links
- [x] Detects broken `rel="up"` chains pointing to unregistered targets
- [x] Detects dead hub spokes whose paths have been removed
- [x] `ValidateAgainstRoutes` flags registered paths missing from routes
- [x] `ValidateAgainstRoutes` flags routes missing from the link graph
- [x] Target-only paths (not sources) still count as graph presence
- [x] Empty registry and empty route edge cases handled

Closes #26