### PR TITLE
feat: add StepperConfig for multi-step wizard flows

### DIFF
--- a/stepper.go
+++ b/stepper.go
@@ -1,0 +1,103 @@
+package linkwell
+
+// StepStatus represents the state of a step in a multi-step wizard flow.
+type StepStatus string
+
+const (
+	// StepPending indicates the step has not been reached yet.
+	StepPending StepStatus = "pending"
+	// StepActive indicates the step is the current step.
+	StepActive StepStatus = "active"
+	// StepComplete indicates the step has been completed.
+	StepComplete StepStatus = "complete"
+	// StepSkipped indicates the step was skipped.
+	StepSkipped StepStatus = "skipped"
+)
+
+// Default labels for stepper navigation controls.
+const (
+	LabelPrevious = "Previous"
+	LabelNext     = "Next"
+	LabelSubmit   = "Submit"
+)
+
+// Step describes a single step in a multi-step wizard flow.
+type Step struct {
+	// Label is the user-visible name for this step.
+	Label string
+	// Href is the URL for this step.
+	Href string
+	// Status is the current state of this step (pending, active, complete, skipped).
+	Status StepStatus
+	// Icon is an optional icon name rendered alongside the step label.
+	Icon Icon
+}
+
+// StepperConfig describes a multi-step wizard flow where the server knows the
+// full step sequence, current position, and completion state. Templates consume
+// this to render step indicators, progress bars, and navigation controls.
+type StepperConfig struct {
+	// Steps is the ordered list of steps in the wizard.
+	Steps []Step
+	// Current is the 0-based index of the active step.
+	Current int
+	// Prev is a navigation control pointing to the previous step. Nil if the
+	// current step is the first step.
+	Prev *Control
+	// Next is a navigation control pointing to the next step. Nil if the
+	// current step is the last step.
+	Next *Control
+	// Submit is a submit control shown only on the final step. Nil on all
+	// other steps.
+	Submit *Control
+}
+
+// NewStepper creates a StepperConfig from the given current index and steps.
+// Steps before currentIndex are marked Complete, the step at currentIndex is
+// marked Active, and steps after are marked Pending. Pre-set statuses (e.g.,
+// StepSkipped) are preserved — only StepPending statuses are overwritten.
+//
+// Navigation controls are auto-generated: Prev points to the previous step's
+// Href (nil on the first step), Next points to the next step's Href (nil on
+// the last step), and Submit is generated only on the final step.
+func NewStepper(currentIndex int, steps ...Step) StepperConfig {
+	out := make([]Step, len(steps))
+	copy(out, steps)
+
+	for i := range out {
+		switch {
+		case i < currentIndex:
+			if out[i].Status == "" || out[i].Status == StepPending {
+				out[i].Status = StepComplete
+			}
+		case i == currentIndex:
+			out[i].Status = StepActive
+		default:
+			if out[i].Status == "" {
+				out[i].Status = StepPending
+			}
+		}
+	}
+
+	cfg := StepperConfig{
+		Steps:   out,
+		Current: currentIndex,
+	}
+
+	if currentIndex > 0 && currentIndex < len(out) {
+		prev := RedirectLink(LabelPrevious, out[currentIndex-1].Href)
+		cfg.Prev = &prev
+	}
+
+	if currentIndex < len(out)-1 {
+		next := RedirectLink(LabelNext, out[currentIndex+1].Href)
+		cfg.Next = &next
+	}
+
+	if currentIndex == len(out)-1 && len(out) > 0 {
+		submit := RedirectLink(LabelSubmit, out[currentIndex].Href).WithVariant(VariantPrimary)
+		cfg.Submit = &submit
+	}
+
+	return cfg
+}

--- a/stepper_test.go
+++ b/stepper_test.go
@@ -1,0 +1,152 @@
+package linkwell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStepper_MiddleStep(t *testing.T) {
+	stepper := NewStepper(1,
+		Step{Label: "Account", Href: "/onboard/account"},
+		Step{Label: "Profile", Href: "/onboard/profile"},
+		Step{Label: "Preferences", Href: "/onboard/prefs"},
+		Step{Label: "Review", Href: "/onboard/review"},
+	)
+
+	require.Len(t, stepper.Steps, 4)
+	require.Equal(t, 1, stepper.Current)
+
+	// Steps before current are Complete.
+	require.Equal(t, StepComplete, stepper.Steps[0].Status)
+	// Current step is Active.
+	require.Equal(t, StepActive, stepper.Steps[1].Status)
+	// Steps after current are Pending.
+	require.Equal(t, StepPending, stepper.Steps[2].Status)
+	require.Equal(t, StepPending, stepper.Steps[3].Status)
+
+	// Prev points to step 0.
+	require.NotNil(t, stepper.Prev)
+	require.Equal(t, "/onboard/account", stepper.Prev.Href)
+	require.Equal(t, LabelPrevious, stepper.Prev.Label)
+	require.Equal(t, ControlKindLink, stepper.Prev.Kind)
+
+	// Next points to step 2.
+	require.NotNil(t, stepper.Next)
+	require.Equal(t, "/onboard/prefs", stepper.Next.Href)
+	require.Equal(t, LabelNext, stepper.Next.Label)
+	require.Equal(t, ControlKindLink, stepper.Next.Kind)
+
+	// Submit is nil (not on last step).
+	require.Nil(t, stepper.Submit)
+}
+
+func TestNewStepper_FirstStep(t *testing.T) {
+	stepper := NewStepper(0,
+		Step{Label: "Account", Href: "/onboard/account"},
+		Step{Label: "Profile", Href: "/onboard/profile"},
+		Step{Label: "Preferences", Href: "/onboard/prefs"},
+	)
+
+	require.Equal(t, StepActive, stepper.Steps[0].Status)
+	require.Equal(t, StepPending, stepper.Steps[1].Status)
+	require.Equal(t, StepPending, stepper.Steps[2].Status)
+
+	// No Prev on first step.
+	require.Nil(t, stepper.Prev)
+
+	// Next points to step 1.
+	require.NotNil(t, stepper.Next)
+	require.Equal(t, "/onboard/profile", stepper.Next.Href)
+
+	// Submit is nil (not on last step).
+	require.Nil(t, stepper.Submit)
+}
+
+func TestNewStepper_LastStep(t *testing.T) {
+	stepper := NewStepper(2,
+		Step{Label: "Account", Href: "/onboard/account"},
+		Step{Label: "Profile", Href: "/onboard/profile"},
+		Step{Label: "Review", Href: "/onboard/review"},
+	)
+
+	require.Equal(t, StepComplete, stepper.Steps[0].Status)
+	require.Equal(t, StepComplete, stepper.Steps[1].Status)
+	require.Equal(t, StepActive, stepper.Steps[2].Status)
+
+	// Prev points to step 1.
+	require.NotNil(t, stepper.Prev)
+	require.Equal(t, "/onboard/profile", stepper.Prev.Href)
+
+	// No Next on last step.
+	require.Nil(t, stepper.Next)
+
+	// Submit is present on last step.
+	require.NotNil(t, stepper.Submit)
+	require.Equal(t, LabelSubmit, stepper.Submit.Label)
+	require.Equal(t, "/onboard/review", stepper.Submit.Href)
+	require.Equal(t, VariantPrimary, stepper.Submit.Variant)
+}
+
+func TestNewStepper_SingleStep(t *testing.T) {
+	stepper := NewStepper(0,
+		Step{Label: "Only Step", Href: "/only"},
+	)
+
+	require.Len(t, stepper.Steps, 1)
+	require.Equal(t, StepActive, stepper.Steps[0].Status)
+
+	// Single step: no Prev, no Next.
+	require.Nil(t, stepper.Prev)
+	require.Nil(t, stepper.Next)
+
+	// Single step is also the last step, so Submit is present.
+	require.NotNil(t, stepper.Submit)
+	require.Equal(t, LabelSubmit, stepper.Submit.Label)
+}
+
+func TestNewStepper_PreservesSkippedStatus(t *testing.T) {
+	stepper := NewStepper(2,
+		Step{Label: "Account", Href: "/account"},
+		Step{Label: "Optional", Href: "/optional", Status: StepSkipped},
+		Step{Label: "Review", Href: "/review"},
+	)
+
+	// Skipped status is preserved even though the step is before current.
+	require.Equal(t, StepSkipped, stepper.Steps[1].Status)
+	// Regular step before current is marked Complete.
+	require.Equal(t, StepComplete, stepper.Steps[0].Status)
+	require.Equal(t, StepActive, stepper.Steps[2].Status)
+}
+
+func TestNewStepper_PreservesIcons(t *testing.T) {
+	stepper := NewStepper(0,
+		Step{Label: "Account", Href: "/account", Icon: IconHome},
+		Step{Label: "Profile", Href: "/profile", Icon: IconCheck},
+	)
+
+	require.Equal(t, IconHome, stepper.Steps[0].Icon)
+	require.Equal(t, IconCheck, stepper.Steps[1].Icon)
+}
+
+func TestNewStepper_PreservesLabelsAndHrefs(t *testing.T) {
+	stepper := NewStepper(1,
+		Step{Label: "Step A", Href: "/a"},
+		Step{Label: "Step B", Href: "/b"},
+		Step{Label: "Step C", Href: "/c"},
+	)
+
+	require.Equal(t, "Step A", stepper.Steps[0].Label)
+	require.Equal(t, "/a", stepper.Steps[0].Href)
+	require.Equal(t, "Step B", stepper.Steps[1].Label)
+	require.Equal(t, "/b", stepper.Steps[1].Href)
+	require.Equal(t, "Step C", stepper.Steps[2].Label)
+	require.Equal(t, "/c", stepper.Steps[2].Href)
+}
+
+func TestStepStatusConstants(t *testing.T) {
+	require.Equal(t, StepStatus("pending"), StepPending)
+	require.Equal(t, StepStatus("active"), StepActive)
+	require.Equal(t, StepStatus("complete"), StepComplete)
+	require.Equal(t, StepStatus("skipped"), StepSkipped)
+}


### PR DESCRIPTION
## Summary

- Adds `StepperConfig`, `Step`, and `StepStatus` types for server-driven multi-step wizard flows (onboarding, checkout, admin wizards)
- `NewStepper` constructor auto-marks step statuses, generates Prev/Next navigation controls, and adds a Submit control on the final step
- Pre-set statuses (e.g., `StepSkipped`) are preserved rather than overwritten

## Test plan

- [x] Middle step: previous steps marked Complete, current Active, remaining Pending; Prev/Next controls generated, no Submit
- [x] First step: no Prev control, Next points to second step
- [x] Last step: Prev present, no Next, Submit generated with VariantPrimary
- [x] Single step: no Prev/Next, Submit present
- [x] StepSkipped status preserved across the boundary
- [x] Icons, labels, and hrefs preserved through construction

Closes #23