### PR TITLE
fix: ValidateGraph excludes self-links from orphan detection

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -25,9 +25,13 @@ func ValidateGraph() []LinkIssue {
 	var issues []LinkIssue
 
 	// Build set of all paths that are link targets (inbound links).
+	// Self-links do not count: orphan means no inbound links from any OTHER path.
 	inbound := make(map[string]bool)
-	for _, links := range all {
+	for source, links := range all {
 		for _, l := range links {
+			if l.Href == source {
+				continue
+			}
 			inbound[l.Href] = true
 		}
 	}

--- a/validate_test.go
+++ b/validate_test.go
@@ -42,6 +42,28 @@ func TestValidateGraph_Orphan(t *testing.T) {
 	assert.Contains(t, orphans[0].Message, "no inbound links")
 }
 
+func TestValidateGraph_SelfLinkIsOrphan(t *testing.T) {
+	resetLinks(t)
+
+	// /foo's only "inbound" link is a self-link — it should still be
+	// flagged as an orphan because self-links don't count as inbound.
+	linksMu.Lock()
+	linksMap["/foo"] = []LinkRelation{
+		{Rel: RelRelated, Href: "/foo", Title: "Foo"},
+	}
+	linksMu.Unlock()
+
+	issues := ValidateGraph()
+	var orphans []LinkIssue
+	for _, i := range issues {
+		if i.Kind == "orphan" && i.Path == "/foo" {
+			orphans = append(orphans, i)
+		}
+	}
+	require.Len(t, orphans, 1, "self-linked page should be flagged as orphan")
+	assert.Contains(t, orphans[0].Message, "no inbound links")
+}
+
 func TestValidateGraph_BrokenUp(t *testing.T) {
 	resetLinks(t)
 


### PR DESCRIPTION
## Summary

`ValidateGraph` built its inbound-link set by iterating every registered path's links and marking each `l.Href` as inbound, without looking at the source path. That meant a page whose only "inbound" link was a self-link was incorrectly considered non-orphaned. Per the docs, an orphan is a registered path with no inbound links from any OTHER path.

The fix iterates with the source path key and skips links where `l.Href == source`, so self-links no longer count as inbound.

Closes #51

## Test plan

- [x] Added `TestValidateGraph_SelfLinkIsOrphan` regression test covering a path whose only link points at itself
- [x] `TestValidateGraph_Ring_NoOrphans` already covers that paths with genuine inbound links from other paths are not flagged
- [x] `go test ./...` passes (ValidateGraph tests stable across 20 runs)
- [x] `go vet ./...` clean