### PR TITLE
fix: NewStepper clamps invalid currentIndex values

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,8 @@ stepper := linkwell.NewStepper(1, // currently on step 2 (0-indexed)
 - `Next` control points to the next step (nil on last)
 - `Submit` control appears only on the final step (with `VariantPrimary`)
 
+Invalid `currentIndex` values are clamped into the valid range `[0, len(steps)-1]`. Empty steps return an empty config with no navigation controls.
+
 ## Action Patterns
 
 > HATEOAS: Hypermedia As The Engine Of Application State. Yes, it is an ugly acronym. The truth is not always beautiful. Sometimes the truth is an ugly acronym that you should have tattooed on the inside of your eyelids.

--- a/stepper.go
+++ b/stepper.go
@@ -60,7 +60,22 @@ type StepperConfig struct {
 // Navigation controls are auto-generated: Prev points to the previous step's
 // Href (nil on the first step), Next points to the next step's Href (nil on
 // the last step), and Submit is generated only on the final step.
+//
+// Invalid currentIndex values are clamped into the valid range
+// [0, len(steps)-1]. Empty steps return an empty config with no navigation
+// controls.
 func NewStepper(currentIndex int, steps ...Step) StepperConfig {
+	if len(steps) == 0 {
+		return StepperConfig{Steps: []Step{}, Current: 0}
+	}
+
+	if currentIndex < 0 {
+		currentIndex = 0
+	}
+	if currentIndex >= len(steps) {
+		currentIndex = len(steps) - 1
+	}
+
 	out := make([]Step, len(steps))
 	copy(out, steps)
 

--- a/stepper_test.go
+++ b/stepper_test.go
@@ -150,3 +150,156 @@ func TestStepStatusConstants(t *testing.T) {
 	require.Equal(t, StepStatus("complete"), StepComplete)
 	require.Equal(t, StepStatus("skipped"), StepSkipped)
 }
+
+func TestNewStepper_NegativeIndexClampsToZero(t *testing.T) {
+	stepper := NewStepper(-1,
+		Step{Label: "Account", Href: "/onboard/account"},
+		Step{Label: "Profile", Href: "/onboard/profile"},
+		Step{Label: "Review", Href: "/onboard/review"},
+	)
+
+	require.Len(t, stepper.Steps, 3)
+	require.Equal(t, 0, stepper.Current)
+
+	// Behaves as if currentIndex == 0.
+	require.Equal(t, StepActive, stepper.Steps[0].Status)
+	require.Equal(t, StepPending, stepper.Steps[1].Status)
+	require.Equal(t, StepPending, stepper.Steps[2].Status)
+
+	// No Prev on first step.
+	require.Nil(t, stepper.Prev)
+
+	// Next points to step 1.
+	require.NotNil(t, stepper.Next)
+	require.Equal(t, "/onboard/profile", stepper.Next.Href)
+
+	// Not the last step, so no Submit.
+	require.Nil(t, stepper.Submit)
+
+	// Exactly one Active step.
+	requireExactlyOneActive(t, stepper.Steps)
+}
+
+func TestNewStepper_NegativeIndexSingleStep(t *testing.T) {
+	stepper := NewStepper(-5,
+		Step{Label: "Only Step", Href: "/only"},
+	)
+
+	require.Len(t, stepper.Steps, 1)
+	require.Equal(t, 0, stepper.Current)
+	require.Equal(t, StepActive, stepper.Steps[0].Status)
+
+	// Single step: no Prev, no Next.
+	require.Nil(t, stepper.Prev)
+	require.Nil(t, stepper.Next)
+
+	// Single step is also the last step, so Submit is present.
+	require.NotNil(t, stepper.Submit)
+	require.Equal(t, LabelSubmit, stepper.Submit.Label)
+}
+
+func TestNewStepper_IndexEqualsLenClampsToLast(t *testing.T) {
+	stepper := NewStepper(3,
+		Step{Label: "Account", Href: "/onboard/account"},
+		Step{Label: "Profile", Href: "/onboard/profile"},
+		Step{Label: "Review", Href: "/onboard/review"},
+	)
+
+	require.Len(t, stepper.Steps, 3)
+	require.Equal(t, 2, stepper.Current)
+
+	// Behaves as if currentIndex == len(steps)-1.
+	require.Equal(t, StepComplete, stepper.Steps[0].Status)
+	require.Equal(t, StepComplete, stepper.Steps[1].Status)
+	require.Equal(t, StepActive, stepper.Steps[2].Status)
+
+	// Prev points to step 1.
+	require.NotNil(t, stepper.Prev)
+	require.Equal(t, "/onboard/profile", stepper.Prev.Href)
+
+	// Last step: no Next.
+	require.Nil(t, stepper.Next)
+
+	// Submit present on last step.
+	require.NotNil(t, stepper.Submit)
+	require.Equal(t, LabelSubmit, stepper.Submit.Label)
+	require.Equal(t, "/onboard/review", stepper.Submit.Href)
+	require.Equal(t, VariantPrimary, stepper.Submit.Variant)
+
+	requireExactlyOneActive(t, stepper.Steps)
+}
+
+func TestNewStepper_IndexFarPastEndClampsToLast(t *testing.T) {
+	stepper := NewStepper(100,
+		Step{Label: "Account", Href: "/onboard/account"},
+		Step{Label: "Profile", Href: "/onboard/profile"},
+		Step{Label: "Review", Href: "/onboard/review"},
+	)
+
+	require.Len(t, stepper.Steps, 3)
+	require.Equal(t, 2, stepper.Current)
+
+	require.Equal(t, StepComplete, stepper.Steps[0].Status)
+	require.Equal(t, StepComplete, stepper.Steps[1].Status)
+	require.Equal(t, StepActive, stepper.Steps[2].Status)
+
+	require.NotNil(t, stepper.Prev)
+	require.Equal(t, "/onboard/profile", stepper.Prev.Href)
+	require.Nil(t, stepper.Next)
+	require.NotNil(t, stepper.Submit)
+	require.Equal(t, "/onboard/review", stepper.Submit.Href)
+
+	requireExactlyOneActive(t, stepper.Steps)
+}
+
+func TestNewStepper_EmptySteps(t *testing.T) {
+	require.NotPanics(t, func() {
+		stepper := NewStepper(0)
+
+		require.NotNil(t, stepper.Steps)
+		require.Empty(t, stepper.Steps)
+		require.Equal(t, 0, stepper.Current)
+		require.Nil(t, stepper.Prev)
+		require.Nil(t, stepper.Next)
+		require.Nil(t, stepper.Submit)
+	})
+}
+
+func TestNewStepper_EmptyStepsNegativeIndex(t *testing.T) {
+	require.NotPanics(t, func() {
+		stepper := NewStepper(-3)
+
+		require.NotNil(t, stepper.Steps)
+		require.Empty(t, stepper.Steps)
+		require.Equal(t, 0, stepper.Current)
+		require.Nil(t, stepper.Prev)
+		require.Nil(t, stepper.Next)
+		require.Nil(t, stepper.Submit)
+	})
+}
+
+func TestNewStepper_EmptyStepsPositiveIndex(t *testing.T) {
+	require.NotPanics(t, func() {
+		stepper := NewStepper(5)
+
+		require.NotNil(t, stepper.Steps)
+		require.Empty(t, stepper.Steps)
+		require.Equal(t, 0, stepper.Current)
+		require.Nil(t, stepper.Prev)
+		require.Nil(t, stepper.Next)
+		require.Nil(t, stepper.Submit)
+	})
+}
+
+// requireExactlyOneActive asserts that exactly one step in the slice has
+// StepActive status, confirming internal consistency of the stepper config.
+func requireExactlyOneActive(t *testing.T, steps []Step) {
+	t.Helper()
+	count := 0
+	for _, s := range steps {
+		if s.Status == StepActive {
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "expected exactly one Active step, got %d", count)
+}


### PR DESCRIPTION
## Summary

`NewStepper` previously accepted any `currentIndex` value and produced inconsistent state:

- Negative `currentIndex`: no step marked Active, but `Next` still pointed at `steps[0]`.
- `currentIndex >= len(steps)`: all steps marked Complete, no Active step, no Submit.
- Empty `steps`: produced a config with nil slice and no early return.

This change clamps the index into the valid range and handles empty steps explicitly so status assignment and Prev/Next/Submit generation stay internally consistent.

## Clamping contract

- `currentIndex < 0` is clamped to `0`.
- `currentIndex > len(steps)-1` is clamped to `len(steps)-1` (when steps is non-empty).
- Empty `steps` returns `StepperConfig{Steps: []Step{}, Current: 0}` with no Prev/Next/Submit and never panics.
- All downstream logic uses the normalized index.

The `NewStepper` signature is unchanged.

Closes #52

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New tests cover: negative index, negative index with single step, index == len, index far past end, empty steps (with zero, negative, and positive index), and an internal-consistency helper asserting exactly one Active step.