### PR TITLE
docs: show HTMX page-size selector pattern alongside PaginationControls

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,79 @@ Generate a URL for a specific page:
 url := info.URLForPage(3) // "/users?q=foo&page=3"
 ```
 
+#### Page-size selector (HTMX companion)
+
+`PaginationControls` owns page-button generation. The per-page `<select>` and
+the hidden-state contract for filters stay in the application — linkwell does
+not render the selector, but the selector should reuse `PageInfo.Target`,
+`PageInfo.Include`, and the same page-parameter name (`page` by default, or
+`PageInfo.PageParam` if you override it).
+
+Render the selector as a sibling of the table, pointing at the same target and
+including the same filter form that `PageInfo.Include` references:
+
+```html
+<form id="filter-form" hx-get="/users" hx-target="#user-table" hx-push-url="true">
+  <input type="hidden" name="q"      value="{{ .Query }}">
+  <input type="hidden" name="role"   value="{{ .Role }}">
+  <input type="hidden" name="status" value="{{ .Status }}">
+</form>
+
+<label for="per-page">Per page</label>
+<select id="per-page" name="limit"
+        hx-get="/users"
+        hx-target="#user-table"
+        hx-include="#filter-form"
+        hx-push-url="true"
+        hx-vals='{"page": "1"}'
+        hx-trigger="change">
+  <option value="10"  {{ if eq .PerPage 10  }}selected{{ end }}>10</option>
+  <option value="25"  {{ if eq .PerPage 25  }}selected{{ end }}>25</option>
+  <option value="50"  {{ if eq .PerPage 50  }}selected{{ end }}>50</option>
+  <option value="100" {{ if eq .PerPage 100 }}selected{{ end }}>100</option>
+</select>
+```
+
+If the surface uses `hx-replace-url` instead of `hx-push-url`, keep that
+choice aligned between the selector and the rest of the pagination UI.
+
+Pair it with `PageInfo` that uses the same target and include selector:
+
+```go
+info := linkwell.PageInfo{
+    BaseURL:    "/users",
+    Page:       page,
+    PerPage:    perPage,
+    TotalItems: total,
+    TotalPages: linkwell.ComputeTotalPages(total, perPage),
+    Target:     "#user-table",
+    Include:    "#filter-form",
+}
+controls := linkwell.PaginationControls(info)
+```
+
+Why each piece exists:
+
+- `hx-include="#filter-form"` pulls current filter values from the filter form
+  on every limit change. The same selector goes into `PageInfo.Include`, so
+  page buttons and the size selector forward identical state.
+- `hx-vals='{"page": "1"}'` resets the page parameter on every limit change.
+  Without it, a user on page 12 of 20 (`limit=10`) who switches to `limit=50`
+  would request page 12 of a 4-page result set. If you set
+  `PageInfo.PageParam`, use that parameter name in `hx-vals` instead of
+  `page`.
+- `hx-target` matches `PageInfo.Target` so both controls swap the same
+  fragment. The filter form lives outside `#user-table`, so its hidden state
+  persists across table swaps.
+- `hx-push-url` (or `hx-replace-url`) should match the history behavior used by
+  the rest of the surface so pagination buttons and the size selector update
+  the browser URL consistently.
+- Hidden `<input>` entries carry filter state that the server already has but
+  the next request needs to see. Server handlers read `limit` as a normal
+  query parameter and recompute `PageInfo` from it.
+
+See [recipes.md](recipes.md) for a fuller list-surface example.
+
 ## Modals
 
 `ModalConfig` describes everything needed to render a modal dialog.

--- a/links.go
+++ b/links.go
@@ -207,34 +207,66 @@ func linksForExact(path string, rels ...string) []LinkRelation {
 	return filtered
 }
 
-// registeredTitleFor returns the title registered for targetPath by checking
-// its parent's links first (via rel="up"), then scanning all registry entries.
-// Returns "" if no registered title is found.
+// registeredTitleFor returns the best registered title for targetPath. It
+// prefers the title from the page's parent link back to the page, then any
+// incoming rel="up" title, then other incoming non-related titles, and finally
+// incoming rel="related" titles. Returns "" if no registered title is found.
 func registeredTitleFor(targetPath string) string {
 	linksMu.RLock()
 	defer linksMu.RUnlock()
 
-	// Check the immediate parent (via rel="up") for a link targeting this path.
-	for _, l := range linksMap[targetPath] {
-		if l.Rel == RelUp {
-			for _, pl := range linksMap[l.Href] {
-				if pl.Href == targetPath && pl.Title != "" {
-					return pl.Title
-				}
+	return registeredTitleForMap(targetPath, linksMap)
+}
+
+func registeredTitleForMap(targetPath string, all map[string][]LinkRelation) string {
+	// If this page has a parent, prefer the parent's label for the page. This
+	// preserves spoke/child titles over generic path-derived inverse titles.
+	for _, l := range all[targetPath] {
+		if l.Rel != RelUp {
+			continue
+		}
+		for _, pl := range all[l.Href] {
+			if pl.Href == targetPath && pl.Title != "" {
+				return pl.Title
 			}
 		}
 	}
 
-	// Fallback: scan all entries for any link targeting this path with a title.
-	for _, links := range linksMap {
+	sources := make([]string, 0, len(all))
+	for source := range all {
+		sources = append(sources, source)
+	}
+	sort.Strings(sources)
+
+	var nonRelatedTitle string
+	var relatedTitle string
+
+	// Fallback: scan all incoming links with relation-aware precedence.
+	for _, source := range sources {
+		links := all[source]
 		for _, l := range links {
-			if l.Href == targetPath && l.Title != "" {
+			if l.Href != targetPath || l.Title == "" {
+				continue
+			}
+			if l.Rel == RelUp {
 				return l.Title
 			}
+			if l.Rel == RelRelated {
+				if relatedTitle == "" {
+					relatedTitle = l.Title
+				}
+				continue
+			}
+			if nonRelatedTitle == "" {
+				nonRelatedTitle = l.Title
+			}
 		}
 	}
 
-	return ""
+	if nonRelatedTitle != "" {
+		return nonRelatedTitle
+	}
+	return relatedTitle
 }
 
 // hasLink checks if a link with the given href and rel already exists.

--- a/recipes.md
+++ b/recipes.md
@@ -83,14 +83,74 @@ cols := []linkwell.TableCol{
 pageInfo := linkwell.PageInfo{
     BaseURL:    "/users",
     Page:       page,
-    PerPage:    25,
+    PerPage:    perPage,
     TotalItems: totalUsers,
-    TotalPages: linkwell.ComputeTotalPages(totalUsers, 25),
+    TotalPages: linkwell.ComputeTotalPages(totalUsers, perPage),
     Target:     "#user-table",
     Include:    "#filter-form",
 }
 pagination := linkwell.PaginationControls(pageInfo)
 ```
+
+### Page-size selector + preserved filter state
+
+linkwell generates the page buttons. The per-page `<select>` and the hidden
+inputs that preserve filter state across partial swaps stay in the application
+template. The contract is: same `hx-target`, same `hx-include`, same history
+behavior (`hx-push-url` or `hx-replace-url`), and `hx-vals` resetting whatever
+page parameter `PageInfo` uses (`page` by default).
+
+```html
+<form id="filter-form"
+      hx-get="/users"
+      hx-target="#user-table"
+      hx-push-url="true">
+  <!-- Visible filter inputs (rendered from linkwell.FilterBar). -->
+  <input type="search" name="q"      value="{{ .Query }}"  placeholder="Search users…">
+  <select name="role">…</select>
+  <select name="status">…</select>
+
+  <!-- Hidden state that must survive partial swaps but is not user-edited
+       on this surface (e.g., the active sort column). The table swap
+       replaces #user-table only; the form persists, so these stay set. -->
+  <input type="hidden" name="sort" value="{{ .SortKey }}">
+  <input type="hidden" name="dir"  value="{{ .SortDir }}">
+</form>
+
+<label for="per-page">Per page</label>
+<select id="per-page" name="limit"
+        hx-get="/users"
+        hx-target="#user-table"
+        hx-include="#filter-form"
+        hx-push-url="true"
+        hx-vals='{"page": "1"}'
+        hx-trigger="change">
+  <option value="10"  {{ if eq .PerPage 10  }}selected{{ end }}>10</option>
+  <option value="25"  {{ if eq .PerPage 25  }}selected{{ end }}>25</option>
+  <option value="50"  {{ if eq .PerPage 50  }}selected{{ end }}>50</option>
+  <option value="100" {{ if eq .PerPage 100 }}selected{{ end }}>100</option>
+</select>
+
+<div id="user-table">
+  <!-- table + linkwell.PaginationControls rendered here; swap replaces this div -->
+</div>
+```
+
+If the surface uses `hx-replace-url` instead, mirror that choice on both the
+form and the selector.
+
+Boundary:
+
+- **linkwell** owns the page-button slice (`PaginationControls`) and the URL
+  builder (`PageInfo.URLForPage`). Page buttons read `PageInfo.Target` and
+  `PageInfo.Include` to forward filter state.
+- **Application** owns the page-size `<select>`, its `hx-include` selector
+  string, the hidden inputs that carry non-edited state across swaps, and the
+  `hx-vals='{"page": "1"}'` reset on limit change.
+
+Server handler reads `limit` like any other query parameter and feeds it into
+`PageInfo.PerPage`. If you override `PageInfo.PageParam`, use that parameter
+name in the selector's `hx-vals`. No new linkwell API is involved.
 
 ### Row actions
 

--- a/sitemap.go
+++ b/sitemap.go
@@ -51,16 +51,6 @@ func Sitemap() []SitemapEntry {
 		}
 	}
 
-	// Build registered title map from link targets.
-	registeredTitles := make(map[string]string, len(all))
-	for _, links := range all {
-		for _, l := range links {
-			if l.Title != "" {
-				registeredTitles[l.Href] = l.Title
-			}
-		}
-	}
-
 	paths := make([]string, 0, len(pathSet))
 	for p := range pathSet {
 		paths = append(paths, p)
@@ -75,10 +65,11 @@ func Sitemap() []SitemapEntry {
 			Path: p,
 		}
 
-		// Resolve title: prefer hub title, then registered title, then derive from path.
+		// Resolve title: prefer hub title, then best registered incoming title,
+		// then derive from the path.
 		if t, ok := hubTitles[p]; ok {
 			entry.Title = t
-		} else if t, ok := registeredTitles[p]; ok {
+		} else if t := registeredTitleForMap(p, all); t != "" {
 			entry.Title = t
 		} else {
 			entry.Title = TitleFromPath(p)


### PR DESCRIPTION
## Summary
- document recommended HTMX page-size selector pattern alongside `PaginationControls`
- show preserved filter state, shared target/include semantics, page reset on `limit` change, and `PageInfo.PageParam` / history alignment
- fix sitemap title precedence so registered titles win when a path is both a source and a target

## Validation
- `go test ./...`
- `go test -race ./...`

Closes #61