### PR TITLE
Fix nav prefix active longest match

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -95,26 +95,40 @@ func SetActiveNavItem(items []NavItem, currentPath string) []NavItem {
 }
 
 // SetActiveNavItemPrefix sets the Active flag using longest-prefix matching.
-// An item is active if the current path equals its Href or starts with Href
-// followed by "/". Use for section-level navigation where /users should be
-// active when the path is /users/42/edit. A parent is marked active if any
-// child matches. Returns a new slice; the input is not modified.
+// An item self-matches when the current path equals its Href or starts with
+// Href followed by "/". Among sibling items, only the single best self-match
+// wins: exact match, else the longest path-segment-bounded prefix, so flat
+// siblings like /app/sales-goals and /app/sales-goals/agents never activate
+// together. A parent is also marked active if any child matches, independent
+// of sibling selection. Use for section-level navigation where /users should
+// be active when the path is /users/42/edit. Returns a new slice; the input is
+// not modified.
 func SetActiveNavItemPrefix(items []NavItem, currentPath string) []NavItem {
 	result := make([]NavItem, len(items))
+	bestIdx := -1
+	bestLen := -1
 	for i, item := range items {
 		item.Children = SetActiveNavItemPrefix(item.Children, currentPath)
+		result[i] = item
+		// Require href+separator to avoid "/" matching every path. Longer Href
+		// means a deeper segment-bounded prefix (exact match is longest), so
+		// len comparison picks the best sibling; ties keep the first item.
+		if item.Href != "" &&
+			(currentPath == item.Href || strings.HasPrefix(currentPath, item.Href+"/")) &&
+			len(item.Href) > bestLen {
+			bestLen = len(item.Href)
+			bestIdx = i
+		}
+	}
+	for i := range result {
 		childActive := false
-		for _, child := range item.Children {
+		for _, child := range result[i].Children {
 			if child.Active {
 				childActive = true
 				break
 			}
 		}
-		// Require href+separator to avoid "/" matching every path.
-		isActive := item.Href != "" &&
-			(currentPath == item.Href || strings.HasPrefix(currentPath, item.Href+"/"))
-		item.Active = isActive || childActive
-		result[i] = item
+		result[i].Active = i == bestIdx || childActive
 	}
 	return result
 }

--- a/nav_test.go
+++ b/nav_test.go
@@ -111,6 +111,65 @@ func TestSetActiveNavItemPrefix_NoMatch(t *testing.T) {
 	}
 }
 
+func TestSetActiveNavItemPrefix_FlatSiblingLongestWins(t *testing.T) {
+	// Issue #63: /app/sales-goals/agents must activate only Agents, not Dashboard.
+	items := []NavItem{
+		{Label: "Dashboard", Href: "/app/sales-goals"},
+		{Label: "Agents", Href: "/app/sales-goals/agents"},
+	}
+	result := SetActiveNavItemPrefix(items, "/app/sales-goals/agents")
+	require.False(t, result[0].Active, "Dashboard (shorter prefix) should not be active")
+	require.True(t, result[1].Active, "Agents (longest match) should be active")
+}
+
+func TestSetActiveNavItemPrefix_ExactBeatsShorterPrefix(t *testing.T) {
+	items := []NavItem{
+		{Label: "Sales Goals", Href: "/app/sales-goals"},
+		{Label: "App", Href: "/app"},
+	}
+	result := SetActiveNavItemPrefix(items, "/app/sales-goals")
+	require.True(t, result[0].Active, "exact match should win")
+	require.False(t, result[1].Active, "shorter prefix should not be active")
+}
+
+func TestSetActiveNavItemPrefix_SegmentBoundaryNotSubstring(t *testing.T) {
+	// /agents must not activate for /agents-old.
+	items := []NavItem{
+		{Label: "Agents", Href: "/agents"},
+	}
+	result := SetActiveNavItemPrefix(items, "/agents-old")
+	require.False(t, result[0].Active, "/agents must not match /agents-old")
+}
+
+func TestSetActiveNavItemPrefix_RootNotActiveForEveryRoute(t *testing.T) {
+	items := []NavItem{
+		{Label: BreadcrumbLabelHome, Href: "/"},
+		{Label: "Users", Href: "/users"},
+	}
+	result := SetActiveNavItemPrefix(items, "/users/42")
+	require.False(t, result[0].Active, "root / should not be active for /users/42")
+	require.True(t, result[1].Active, "Users should be active")
+}
+
+func TestSetActiveNavItemPrefix_ChildBubblesDespiteSiblingWinner(t *testing.T) {
+	// A sibling with a longer self-match must not suppress a parent activated
+	// by its own active child.
+	items := []NavItem{
+		{
+			Label: "Reports",
+			Href:  "/app/reports",
+			Children: []NavItem{
+				{Label: "Monthly", Href: "/app/reports/monthly"},
+			},
+		},
+		{Label: "Reports Archive", Href: "/app/reports-archive"},
+	}
+	result := SetActiveNavItemPrefix(items, "/app/reports/monthly")
+	require.True(t, result[0].Active, "parent Reports active via child")
+	require.True(t, result[0].Children[0].Active, "child Monthly active via prefix")
+	require.False(t, result[1].Active, "unrelated sibling not active")
+}
+
 func TestSetActiveNavItemPrefix_ChildPrefixMatchActivatesParent(t *testing.T) {
 	items := []NavItem{
 		{


### PR DESCRIPTION
## Summary
- make `SetActiveNavItemPrefix` choose one best self-match among flat siblings
- preserve nested child active bubbling
- add regressions for issue #63 root/section collision and segment-boundary matching

Closes #63

## Validation
- `go test ./...`
- `go vet ./...`
- `git diff --check`