### PR TITLE
Add declarative breadcrumb policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,39 @@ linkwell.RemoveLink("/projects/42", "/teams/7", "related")
 >
 > -- The Wisdom of the Uniform Interface
 
+### Declarative Policy (recommended)
+
+`Breadcrumbs()` builds a route-display policy that is decoupled from the link
+graph and sitemap. Declare a mounted-app prefix, an app-local root, and stable
+labels for known routes; supply per-request labels for DB-backed parameters at
+resolve time. The policy is pure data and safe to reuse as a package-level value
+-- `Resolve` never mutates it.
+
+```go
+// Build once (e.g. a package-level value).
+salesCrumbs := linkwell.Breadcrumbs().
+	Prefix("/app/sales-goals"). // trimmed for matching; Hrefs stay absolute
+	Root("Sales Goals").        // app-local root; Href defaults to the prefix
+	Crumb("/subdivisions", "Subdivisions").
+	Crumb("/agents", "Agents")
+
+// At request time, override the ":id" segment with a loaded entity name.
+crumbs := salesCrumbs.Resolve("/app/sales-goals/subdivisions/81",
+	linkwell.CrumbLabel("/subdivisions/:id", "Atwater Villas"),
+)
+// Sales Goals (/app/sales-goals) > Subdivisions (/app/sales-goals/subdivisions)
+//   > [Atwater Villas]
+```
+
+Patterns support exact segments and `:param` segments that each match one path
+segment. Precedence: runtime labels beat policy labels, exact segments beat
+`:param` patterns, and unmatched segments fall back to `TitleFromPath`. The
+terminal crumb has an empty `Href` (current page, rendered as text).
+
+The link-graph and path helpers below remain for sitemap-driven trails and
+simple cases, but the declarative policy is the preferred API for app-local
+breadcrumbs with dynamic labels.
+
 ### From Link Graph
 
 Walk the `rel="up"` chain from a path to build a breadcrumb trail. Requires links registered via `Hub` or `Link` with `rel="up"`. Registered titles are preserved -- if a spoke was registered with a custom title, that title appears in the breadcrumb instead of the path-derived label.

--- a/breadcrumb_policy.go
+++ b/breadcrumb_policy.go
@@ -1,0 +1,203 @@
+package linkwell
+
+import "strings"
+
+// BreadcrumbPolicy is a declarative, request-local description of how a mounted
+// app's routes render as breadcrumbs. It is decoupled from the link graph and
+// sitemap: those describe durable site topology, while a policy describes route
+// display only. It is pure data: build one once (even as a package-level
+// value) and call Resolve per request. Builder methods return a new policy and
+// never mutate the receiver, so shared reuse across requests is safe.
+type BreadcrumbPolicy struct {
+	prefix    string
+	rootLabel string
+	rootHref  string
+	rules     []crumbRule
+}
+
+// crumbRule is a route pattern (relative to the policy prefix) paired with a
+// display label. Segments beginning with ":" match any single path segment.
+type crumbRule struct {
+	segs   []string
+	label  string
+	exacts int // non-":param" segment count, for specificity tiebreak
+}
+
+// CrumbOption is a per-call runtime label, typically a DB/entity name resolved
+// by the handler. Runtime labels override policy labels and are not stored on
+// the policy.
+type CrumbOption struct {
+	rule crumbRule
+}
+
+// Breadcrumbs starts a new empty BreadcrumbPolicy.
+func Breadcrumbs() BreadcrumbPolicy { return BreadcrumbPolicy{} }
+
+// Prefix sets the mounted-app path prefix trimmed before matching. Returned
+// crumb Hrefs remain full absolute paths.
+func (p BreadcrumbPolicy) Prefix(prefix string) BreadcrumbPolicy {
+	p.prefix = normalizeCrumbPath(prefix)
+	return p
+}
+
+// Root sets the root crumb label. With a prefix, its Href defaults to that
+// prefix. Without a prefix, its Href defaults to "/". Override with RootHref.
+func (p BreadcrumbPolicy) Root(label string) BreadcrumbPolicy {
+	p.rootLabel = label
+	return p
+}
+
+// RootHref overrides the app-local root crumb Href, which otherwise defaults to
+// the prefix.
+func (p BreadcrumbPolicy) RootHref(href string) BreadcrumbPolicy {
+	p.rootHref = href
+	return p
+}
+
+// Crumb registers a stable policy label for a route pattern relative to the
+// prefix. Patterns support exact segments and ":param" segments that each match
+// one path segment.
+func (p BreadcrumbPolicy) Crumb(pattern, label string) BreadcrumbPolicy {
+	rules := make([]crumbRule, len(p.rules), len(p.rules)+1)
+	copy(rules, p.rules)
+	p.rules = append(rules, newCrumbRule(pattern, label))
+	return p
+}
+
+// CrumbLabel builds a per-call runtime label for a route pattern. Pass to
+// Resolve to override the policy label for the matching segment, e.g. to supply
+// an entity name for a ":id" segment.
+func CrumbLabel(pattern, label string) CrumbOption {
+	return CrumbOption{rule: newCrumbRule(pattern, label)}
+}
+
+// Resolve renders breadcrumbs for path under this policy. Parent crumbs carry
+// full absolute Hrefs; the terminal (current page) crumb has an empty Href.
+// Runtime labels override policy labels; unmatched segments fall back to
+// TitleFromPath.
+func (p BreadcrumbPolicy) Resolve(path string, runtime ...CrumbOption) []Breadcrumb {
+	path = normalizeCrumbPath(path)
+
+	rel := path
+	hasPrefix := p.prefix == ""
+	if p.prefix != "" {
+		switch {
+		case path == p.prefix:
+			rel, hasPrefix = "", true
+		case strings.HasPrefix(path, p.prefix+"/"):
+			rel, hasPrefix = path[len(p.prefix):], true
+		}
+	}
+
+	relSegs := splitCrumbSegs(rel)
+
+	base := ""
+	if hasPrefix {
+		base = p.prefix
+	}
+
+	var crumbs []Breadcrumb
+	if hasPrefix && p.rootLabel != "" {
+		href := p.rootHref
+		if href == "" {
+			href = "/"
+			if p.prefix != "" {
+				href = p.prefix
+			}
+		}
+		if len(relSegs) == 0 {
+			href = "" // the root itself is the current page
+		}
+		crumbs = append(crumbs, Breadcrumb{Label: p.rootLabel, Href: href})
+	}
+
+	for i := range relSegs {
+		abs := base + "/" + strings.Join(relSegs[:i+1], "/")
+		label := p.labelFor(relSegs[:i+1], runtime)
+		if label == "" {
+			label = TitleFromPath(abs)
+		}
+		href := abs
+		if i == len(relSegs)-1 {
+			href = "" // terminal crumb is the current page
+		}
+		crumbs = append(crumbs, Breadcrumb{Label: label, Href: href})
+	}
+	return crumbs
+}
+
+// labelFor picks the best label for a cumulative path. Runtime labels beat
+// policy labels; within a source, more exact (fewer ":param") patterns win;
+// ties keep the first registered.
+func (p BreadcrumbPolicy) labelFor(pathSegs []string, runtime []CrumbOption) string {
+	best := ""
+	bestScore := -1
+	consider := func(r crumbRule, isRuntime bool) {
+		if !matchCrumbSegs(r.segs, pathSegs) {
+			return
+		}
+		score := r.exacts
+		if isRuntime {
+			score += 1000 // runtime overrides any policy label
+		}
+		if score > bestScore {
+			bestScore = score
+			best = r.label
+		}
+	}
+	for _, r := range p.rules {
+		consider(r, false)
+	}
+	for _, o := range runtime {
+		consider(o.rule, true)
+	}
+	return best
+}
+
+func newCrumbRule(pattern, label string) crumbRule {
+	segs := splitCrumbSegs(pattern)
+	exacts := 0
+	for _, s := range segs {
+		if !strings.HasPrefix(s, ":") {
+			exacts++
+		}
+	}
+	return crumbRule{segs: segs, label: label, exacts: exacts}
+}
+
+// matchCrumbSegs reports whether pattern matches path. ":param" segments match
+// any single segment; lengths must be equal, so a param never spans segments.
+func matchCrumbSegs(pattern, path []string) bool {
+	if len(pattern) != len(path) {
+		return false
+	}
+	for i, ps := range pattern {
+		if strings.HasPrefix(ps, ":") {
+			continue
+		}
+		if ps != path[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func splitCrumbSegs(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
+}
+
+// normalizeCrumbPath strips any query/fragment and trailing slash so matching
+// is stable. The root "/" is preserved.
+func normalizeCrumbPath(path string) string {
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		path = path[:i]
+	}
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+	}
+	return path
+}

--- a/breadcrumb_policy_test.go
+++ b/breadcrumb_policy_test.go
@@ -1,0 +1,125 @@
+package linkwell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func salesPolicy() BreadcrumbPolicy {
+	return Breadcrumbs().
+		Prefix("/app/sales-goals").
+		Root("Sales Goals").
+		Crumb("/subdivisions", "Subdivisions").
+		Crumb("/agents", "Agents")
+}
+
+func labels(crumbs []Breadcrumb) []string {
+	out := make([]string, len(crumbs))
+	for i, c := range crumbs {
+		out[i] = c.Label
+	}
+	return out
+}
+
+func TestBreadcrumbPolicy_StaticSection(t *testing.T) {
+	crumbs := salesPolicy().Resolve("/app/sales-goals/subdivisions")
+	require.Equal(t, []string{"Sales Goals", "Subdivisions"}, labels(crumbs))
+	require.Equal(t, "/app/sales-goals", crumbs[0].Href)
+	require.Empty(t, crumbs[1].Href, "terminal crumb is unlinked")
+}
+
+func TestBreadcrumbPolicy_RuntimeEntityLabel(t *testing.T) {
+	crumbs := salesPolicy().Resolve("/app/sales-goals/subdivisions/81",
+		CrumbLabel("/subdivisions/:id", "Atwater Villas"),
+	)
+	require.Equal(t, []string{"Sales Goals", "Subdivisions", "Atwater Villas"}, labels(crumbs))
+	require.Equal(t, "/app/sales-goals/subdivisions", crumbs[1].Href)
+	require.Empty(t, crumbs[2].Href)
+}
+
+func TestBreadcrumbPolicy_RuntimeAgentLabel(t *testing.T) {
+	crumbs := salesPolicy().Resolve("/app/sales-goals/agents/346",
+		CrumbLabel("/agents/:id", "Ashley Pope"),
+	)
+	require.Equal(t, []string{"Sales Goals", "Agents", "Ashley Pope"}, labels(crumbs))
+	require.NotEqual(t, "346", crumbs[2].Label, "no raw numeric terminal label")
+}
+
+func TestBreadcrumbPolicy_DeepDynamicRoute(t *testing.T) {
+	crumbs := salesPolicy().Resolve("/app/sales-goals/subdivisions/81/edit",
+		CrumbLabel("/subdivisions/:id", "Atwater Villas"),
+	)
+	require.Equal(t,
+		[]string{"Sales Goals", "Subdivisions", "Atwater Villas", "Edit"},
+		labels(crumbs))
+	require.Equal(t, "/app/sales-goals/subdivisions/81", crumbs[2].Href)
+	require.Empty(t, crumbs[3].Href)
+}
+
+func TestBreadcrumbPolicy_PrefixItselfIsTerminalRoot(t *testing.T) {
+	crumbs := salesPolicy().Resolve("/app/sales-goals")
+	require.Equal(t, []string{"Sales Goals"}, labels(crumbs))
+	require.Empty(t, crumbs[0].Href, "root is the current page")
+}
+
+func TestBreadcrumbPolicy_RuntimeBeatsPolicyLabel(t *testing.T) {
+	p := salesPolicy().Crumb("/subdivisions/:id", "Subdivision")
+	crumbs := p.Resolve("/app/sales-goals/subdivisions/81",
+		CrumbLabel("/subdivisions/:id", "Atwater Villas"),
+	)
+	require.Equal(t, "Atwater Villas", crumbs[2].Label)
+}
+
+func TestBreadcrumbPolicy_ExactBeatsParamPattern(t *testing.T) {
+	p := Breadcrumbs().Prefix("/app").Root("App").
+		Crumb("/users/:id", "Some User").
+		Crumb("/users/new", "New User")
+	crumbs := p.Resolve("/app/users/new")
+	require.Equal(t, "New User", crumbs[len(crumbs)-1].Label)
+}
+
+func TestBreadcrumbPolicy_FallbackTitleFromPath(t *testing.T) {
+	crumbs := salesPolicy().Resolve("/app/sales-goals/error-traces")
+	require.Equal(t, "Error Traces", crumbs[1].Label)
+}
+
+func TestBreadcrumbPolicy_NormalizesTrailingSlashAndQuery(t *testing.T) {
+	crumbs := salesPolicy().Resolve("/app/sales-goals/subdivisions/?page=2#top")
+	require.Equal(t, []string{"Sales Goals", "Subdivisions"}, labels(crumbs))
+	require.Empty(t, crumbs[1].Href)
+}
+
+func TestBreadcrumbPolicy_ParamMatchesSingleSegmentOnly(t *testing.T) {
+	// /subdivisions/:id must not match /subdivisions/81/edit at the :id level.
+	p := Breadcrumbs().Prefix("/app").Crumb("/a/:id", "One")
+	crumbs := p.Resolve("/app/a/1/2")
+	require.NotEqual(t, "One", crumbs[len(crumbs)-1].Label)
+}
+
+func TestBreadcrumbPolicy_RootHrefOverride(t *testing.T) {
+	p := salesPolicy().RootHref("/app/sales-goals/home")
+	crumbs := p.Resolve("/app/sales-goals/agents")
+	require.Equal(t, "/app/sales-goals/home", crumbs[0].Href)
+}
+
+func TestBreadcrumbPolicy_GlobalRootWithoutPrefix(t *testing.T) {
+	p := Breadcrumbs().Root("Home").Crumb("/admin/users", "Users")
+	crumbs := p.Resolve("/admin/users")
+	require.Equal(t, []string{"Home", "Admin", "Users"}, labels(crumbs))
+	require.Equal(t, "/", crumbs[0].Href)
+	require.Equal(t, "/admin", crumbs[1].Href)
+	require.Empty(t, crumbs[2].Href)
+}
+
+func TestBreadcrumbPolicy_ReuseDoesNotMutate(t *testing.T) {
+	base := Breadcrumbs().Prefix("/app").Root("App")
+	withUsers := base.Crumb("/users", "People")
+	// base must remain unaffected by the derived policy's Crumb.
+	bc := base.Resolve("/app/users")
+	wc := withUsers.Resolve("/app/users")
+	require.Equal(t, "People", wc[1].Label)
+	require.Equal(t, "Users", bc[1].Label, "fallback title, not the derived rule")
+	require.Len(t, base.rules, 0)
+	require.Len(t, withUsers.rules, 1)
+}

--- a/example_test.go
+++ b/example_test.go
@@ -163,6 +163,29 @@ func ExampleRemoveLink() {
 	// 0
 }
 
+func ExampleBreadcrumbs() {
+	policy := linkwell.Breadcrumbs().
+		Prefix("/app/sales-goals").
+		Root("Sales Goals").
+		Crumb("/subdivisions", "Subdivisions").
+		Crumb("/agents", "Agents")
+
+	crumbs := policy.Resolve("/app/sales-goals/subdivisions/81",
+		linkwell.CrumbLabel("/subdivisions/:id", "Atwater Villas"),
+	)
+	for _, c := range crumbs {
+		if c.Href == "" {
+			fmt.Printf("[%s]\n", c.Label)
+		} else {
+			fmt.Printf("%s (%s)\n", c.Label, c.Href)
+		}
+	}
+	// Output:
+	// Sales Goals (/app/sales-goals)
+	// Subdivisions (/app/sales-goals/subdivisions)
+	// [Atwater Villas]
+}
+
 func ExampleBreadcrumbsFromLinks() {
 	linkwell.ResetForTesting()
 


### PR DESCRIPTION
## Summary
- add `BreadcrumbPolicy` via `Breadcrumbs()` for route-display breadcrumb policy
- support mounted prefixes, app/global roots, static crumbs, and runtime `:param` labels
- add issue #66 coverage plus docs and runnable example

Closes #66

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `git diff --check`