### PR TITLE
Add validated return target helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,39 @@ href := linkwell.FromNav("/users/42", c.QueryParam("from"))
 // "/users/42?from=3" if mask was 3
 ```
 
+### Return Targets
+
+Breadcrumbs and `?from=` describe *origin context* for display; they are not a
+safe place to redirect to. Two navigation concepts are distinct:
+
+- **Canonical parent/back** is structural and server-owned: the durable "up"
+  destination for a page, independent of how the user arrived.
+- **Exact return** is request-specific: the precise page a journey should return
+  to, carried in a query parameter (default `back_to`).
+
+`ReturnTarget` resolves the two into one destination. The exact return is
+accepted only when it is a safe same-origin path (a local absolute path);
+off-origin values such as absolute URLs, `//host`, backslash bypasses, and
+control characters fall back to the server-owned canonical target.
+
+```go
+target := linkwell.ReturnTargetFromRequest(r, linkwell.ReturnTargetConfig{
+	Param: "back_to", // optional; defaults to "back_to"
+	Fallback: linkwell.CanonicalTarget{
+		Label: "Back to vendors",
+		Href:  "/vendors",
+	},
+})
+
+// target.Href is always a safe path to link/redirect to.
+// target.Exact reports whether the request's back_to was accepted.
+ctrl := linkwell.RedirectLink(target.Label, target.Href)
+```
+
+Use `ReturnTargetFromValue(raw, cfg)` when the parameter is read outside
+`net/http`. The `Fallback` href is treated as trusted server-owned data and is
+not re-validated.
+
 ## Controls
 
 > Hypertext is the simultaneous presentation of information and controls such that the information BECOMES THE AFFORDANCE through which choices are obtained and actions are selected.

--- a/example_test.go
+++ b/example_test.go
@@ -258,6 +258,23 @@ func ExampleFromNav() {
 	// /users/42
 }
 
+func ExampleReturnTargetFromValue() {
+	cfg := linkwell.ReturnTargetConfig{
+		Fallback: linkwell.CanonicalTarget{Label: "Back to vendors", Href: "/vendors"},
+	}
+
+	// A safe same-origin path is accepted verbatim (query preserved).
+	safe := linkwell.ReturnTargetFromValue("/vendors/42?tab=orders", cfg)
+	fmt.Printf("%s -> %s (exact=%t)\n", safe.Label, safe.Href, safe.Exact)
+
+	// An off-origin value is rejected; the canonical fallback is used.
+	unsafe := linkwell.ReturnTargetFromValue("//evil.example.com", cfg)
+	fmt.Printf("%s -> %s (exact=%t)\n", unsafe.Label, unsafe.Href, unsafe.Exact)
+	// Output:
+	// Back -> /vendors/42?tab=orders (exact=true)
+	// Back to vendors -> /vendors (exact=false)
+}
+
 func ExampleFromQueryString() {
 	fmt.Println(linkwell.FromQueryString(3))
 	fmt.Println(linkwell.FromQueryString(0))

--- a/return_target.go
+++ b/return_target.go
@@ -1,0 +1,148 @@
+package linkwell
+
+import "net/http"
+
+// Navigation contract (issue #60):
+//
+//   - Canonical parent/back is structural and server-owned: the durable "up"
+//     destination for a page, independent of how the user arrived. Modeled by
+//     CanonicalTarget and supplied by the application, so it is trusted data.
+//   - Exact return is request-specific: the precise page a journey should return
+//     to, carried in a query parameter (default "back_to"). It originates from
+//     the request, so it is validated as a same-origin path before use.
+//   - The ?from= breadcrumb context (see FromNav) is display/origin hinting, not
+//     an exact return target. Never treat a "from" value as a safe redirect.
+//
+// ReturnTarget collapses these into one destination: an accepted same-origin
+// exact return when present and safe, otherwise the canonical fallback.
+
+// DefaultReturnParam is the query parameter consulted for an exact return path
+// when ReturnTargetConfig.Param is empty.
+const DefaultReturnParam = "back_to"
+
+// DefaultReturnLabel is the label applied to an accepted exact return when
+// ReturnTargetConfig.ExactLabel is empty.
+const DefaultReturnLabel = "Back"
+
+// CanonicalTarget is a server-owned structural back/up destination. It is
+// trusted application data (not derived from the request), so its Href is used
+// verbatim and is not subjected to same-origin validation.
+type CanonicalTarget struct {
+	// Label is the user-visible text for the canonical destination.
+	Label string
+	// Href is the canonical destination path (server-owned, trusted).
+	Href string
+}
+
+// ReturnTargetConfig configures how an exact return is read from a request and
+// how the canonical fallback is described.
+type ReturnTargetConfig struct {
+	// Param is the query parameter holding the exact return path. Defaults to
+	// DefaultReturnParam ("back_to") when empty.
+	Param string
+	// ExactLabel is the label for an accepted exact return. Defaults to
+	// DefaultReturnLabel ("Back") when empty.
+	ExactLabel string
+	// Fallback is the canonical target used when no safe exact return is present.
+	Fallback CanonicalTarget
+}
+
+// ReturnTarget is the resolved destination a "return" affordance should use.
+// Exact reports whether Href came from an accepted same-origin exact return
+// (true) or from the canonical fallback (false).
+type ReturnTarget struct {
+	// Label is the user-visible text for the return control.
+	Label string
+	// Href is the resolved, safe destination path.
+	Href string
+	// Exact is true when Href is an accepted exact return, false for fallback.
+	Exact bool
+}
+
+// ReturnTargetFromRequest resolves a ReturnTarget from the request's return
+// parameter, falling back to cfg.Fallback when the parameter is absent or is
+// not a safe same-origin path. A nil request resolves to the fallback.
+func ReturnTargetFromRequest(r *http.Request, cfg ReturnTargetConfig) ReturnTarget {
+	raw := ""
+	if r != nil {
+		raw = r.URL.Query().Get(returnParam(cfg))
+	}
+	return ReturnTargetFromValue(raw, cfg)
+}
+
+// ReturnTargetFromValue resolves a ReturnTarget from an already-extracted raw
+// parameter value. Use when the return value is read outside net/http (e.g. a
+// framework's own query accessor). raw is accepted only when it is a safe local
+// absolute path; otherwise the canonical fallback is returned.
+func ReturnTargetFromValue(raw string, cfg ReturnTargetConfig) ReturnTarget {
+	if safe, ok := safeLocalPath(raw); ok {
+		label := cfg.ExactLabel
+		if label == "" {
+			label = DefaultReturnLabel
+		}
+		return ReturnTarget{Label: label, Href: safe, Exact: true}
+	}
+	return ReturnTarget{Label: cfg.Fallback.Label, Href: cfg.Fallback.Href}
+}
+
+func returnParam(cfg ReturnTargetConfig) string {
+	if cfg.Param == "" {
+		return DefaultReturnParam
+	}
+	return cfg.Param
+}
+
+// safeLocalPath reports whether raw is a same-origin local path safe to use as
+// a return/redirect target, returning the value to use. Query and fragment are
+// preserved; neither can change the origin. Rejected: empty values, values not
+// beginning with a single "/", protocol-relative ("//host") and backslash
+// ("/\host", or any "\" a browser may fold to "/") forms, absolute URLs (which
+// carry a scheme before the first "/"), and values containing raw or
+// percent-encoded control characters or backslashes.
+func safeLocalPath(raw string) (string, bool) {
+	if raw == "" || raw[0] != '/' {
+		return "", false
+	}
+	if len(raw) > 1 && (raw[1] == '/' || raw[1] == '\\') {
+		return "", false
+	}
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if c == '\\' || c < 0x20 || c == 0x7f {
+			return "", false
+		}
+		if c == '%' && unsafeEscapedByte(raw[i:]) {
+			return "", false
+		}
+	}
+	return raw, true
+}
+
+func unsafeEscapedByte(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	hi, ok := fromHex(s[1])
+	if !ok {
+		return false
+	}
+	lo, ok := fromHex(s[2])
+	if !ok {
+		return false
+	}
+	b := hi<<4 | lo
+	return b == '\\' || b < 0x20 || b == 0x7f
+}
+
+func fromHex(c byte) (byte, bool) {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0', true
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10, true
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10, true
+	default:
+		return 0, false
+	}
+}

--- a/return_target_test.go
+++ b/return_target_test.go
@@ -1,0 +1,112 @@
+package linkwell
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func vendorsCfg() ReturnTargetConfig {
+	return ReturnTargetConfig{
+		Param:    "back_to",
+		Fallback: CanonicalTarget{Label: "Back to vendors", Href: "/vendors"},
+	}
+}
+
+func TestReturnTarget_AcceptsExactReturn(t *testing.T) {
+	got := ReturnTargetFromValue("/vendors/42", vendorsCfg())
+	require.True(t, got.Exact)
+	require.Equal(t, "/vendors/42", got.Href)
+	require.Equal(t, "Back", got.Label)
+}
+
+func TestReturnTarget_PreservesQueryAndFragment(t *testing.T) {
+	got := ReturnTargetFromValue("/vendors?q=foo&page=2#row-3", vendorsCfg())
+	require.True(t, got.Exact)
+	require.Equal(t, "/vendors?q=foo&page=2#row-3", got.Href)
+}
+
+func TestReturnTarget_MissingFallsBack(t *testing.T) {
+	got := ReturnTargetFromValue("", vendorsCfg())
+	require.False(t, got.Exact)
+	require.Equal(t, "/vendors", got.Href)
+	require.Equal(t, "Back to vendors", got.Label)
+}
+
+func TestReturnTarget_RejectsAbsoluteURL(t *testing.T) {
+	got := ReturnTargetFromValue("https://evil.example.com/x", vendorsCfg())
+	require.False(t, got.Exact)
+	require.Equal(t, "/vendors", got.Href)
+}
+
+func TestReturnTarget_RejectsProtocolRelative(t *testing.T) {
+	require.False(t, ReturnTargetFromValue("//evil.example.com/x", vendorsCfg()).Exact)
+}
+
+func TestReturnTarget_RejectsBackslashBypass(t *testing.T) {
+	require.False(t, ReturnTargetFromValue(`/\evil.example.com`, vendorsCfg()).Exact)
+	require.False(t, ReturnTargetFromValue(`/vendors\evil`, vendorsCfg()).Exact)
+}
+
+func TestReturnTarget_RejectsEscapedBackslashBypass(t *testing.T) {
+	require.False(t, ReturnTargetFromValue(`/%5Cevil.example.com`, vendorsCfg()).Exact)
+	require.False(t, ReturnTargetFromValue(`/vendors%5cevil`, vendorsCfg()).Exact)
+}
+
+func TestReturnTarget_RejectsControlChars(t *testing.T) {
+	require.False(t, ReturnTargetFromValue("/vendors\n/42", vendorsCfg()).Exact)
+	require.False(t, ReturnTargetFromValue("/vendors\x00", vendorsCfg()).Exact)
+	require.False(t, ReturnTargetFromValue("/vendors\x7f", vendorsCfg()).Exact)
+}
+
+func TestReturnTarget_RejectsEscapedControlChars(t *testing.T) {
+	require.False(t, ReturnTargetFromValue("/vendors%0a/42", vendorsCfg()).Exact)
+	require.False(t, ReturnTargetFromValue("/vendors%00", vendorsCfg()).Exact)
+	require.False(t, ReturnTargetFromValue("/vendors%7F", vendorsCfg()).Exact)
+}
+
+func TestReturnTarget_RejectsRelativePath(t *testing.T) {
+	require.False(t, ReturnTargetFromValue("vendors/42", vendorsCfg()).Exact)
+}
+
+func TestReturnTarget_DefaultParamName(t *testing.T) {
+	req := httptest.NewRequest("GET", "/page?back_to=/vendors/7", nil)
+	got := ReturnTargetFromRequest(req, ReturnTargetConfig{
+		Fallback: CanonicalTarget{Label: "Back to vendors", Href: "/vendors"},
+	})
+	require.True(t, got.Exact)
+	require.Equal(t, "/vendors/7", got.Href)
+}
+
+func TestReturnTarget_CustomParamName(t *testing.T) {
+	cfg := ReturnTargetConfig{Param: "return", Fallback: CanonicalTarget{Href: "/vendors"}}
+
+	hit := httptest.NewRequest("GET", "/page?return=/vendors/7", nil)
+	require.True(t, ReturnTargetFromRequest(hit, cfg).Exact)
+
+	// The default name is not consulted once Param is set.
+	miss := httptest.NewRequest("GET", "/page?back_to=/vendors/7", nil)
+	require.False(t, ReturnTargetFromRequest(miss, cfg).Exact)
+}
+
+func TestReturnTarget_PreservesQueryFromRequest(t *testing.T) {
+	req := httptest.NewRequest("GET", "/page?back_to=%2Fvendors%3Fq%3Dfoo%26page%3D2", nil)
+	got := ReturnTargetFromRequest(req, vendorsCfg())
+	require.True(t, got.Exact)
+	require.Equal(t, "/vendors?q=foo&page=2", got.Href)
+}
+
+func TestReturnTarget_ExactLabelOverride(t *testing.T) {
+	cfg := vendorsCfg()
+	cfg.ExactLabel = "Back to results"
+	got := ReturnTargetFromValue("/vendors?page=2", cfg)
+	require.Equal(t, "Back to results", got.Label)
+}
+
+func TestReturnTarget_NilRequestFallsBack(t *testing.T) {
+	got := ReturnTargetFromRequest(nil, vendorsCfg())
+	require.False(t, got.Exact)
+	require.Equal(t, "/vendors", got.Href)
+	require.Equal(t, "Back to vendors", got.Label)
+}


### PR DESCRIPTION
## Summary
- add `ReturnTarget` helpers for validated exact return paths with canonical fallback
- reject off-origin, protocol-relative, backslash, raw control, and percent-encoded unsafe values
- document canonical parent/back vs exact return vs `from` breadcrumb context

Refs #60

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `git diff --check`