### PR TITLE
feat: add breadcrumb resolver and path-only nav matching

### DIFF
--- a/breadcrumb_resolver.go
+++ b/breadcrumb_resolver.go
@@ -1,0 +1,82 @@
+package linkwell
+
+// BreadcrumbResolveContext carries request-local breadcrumb inputs.
+type BreadcrumbResolveContext struct {
+	// Path is the current request path used by policy and path fallback sources.
+	Path string
+	// Explicit is a route-provided breadcrumb trail.
+	Explicit []Breadcrumb
+	// Parent is an app-provided parent/up breadcrumb trail.
+	Parent []Breadcrumb
+	// RuntimeLabels are per-request labels passed to a BreadcrumbPolicy source.
+	RuntimeLabels []CrumbOption
+	// PathLabels override path-derived fallback labels by segment index.
+	PathLabels map[int]string
+}
+
+// BreadcrumbSource resolves a breadcrumb trail from request-local context.
+type BreadcrumbSource func(BreadcrumbResolveContext) []Breadcrumb
+
+// BreadcrumbResolver tries breadcrumb sources in order and returns the first
+// non-empty trail.
+type BreadcrumbResolver struct {
+	sources []BreadcrumbSource
+}
+
+// NewBreadcrumbResolver builds an ordered breadcrumb fallback resolver.
+func NewBreadcrumbResolver(sources ...BreadcrumbSource) BreadcrumbResolver {
+	copied := make([]BreadcrumbSource, len(sources))
+	copy(copied, sources)
+	return BreadcrumbResolver{sources: copied}
+}
+
+// Resolve returns the first non-empty trail produced by the configured sources.
+func (r BreadcrumbResolver) Resolve(ctx BreadcrumbResolveContext) []Breadcrumb {
+	for _, source := range r.sources {
+		if source == nil {
+			continue
+		}
+		crumbs := cloneBreadcrumbs(source(ctx))
+		if len(crumbs) > 0 {
+			return crumbs
+		}
+	}
+	return nil
+}
+
+// ExplicitBreadcrumbs returns route-provided breadcrumbs from the context.
+func ExplicitBreadcrumbs() BreadcrumbSource {
+	return func(ctx BreadcrumbResolveContext) []Breadcrumb {
+		return cloneBreadcrumbs(ctx.Explicit)
+	}
+}
+
+// ParentBreadcrumbs returns app-provided parent/up breadcrumbs from the context.
+func ParentBreadcrumbs() BreadcrumbSource {
+	return func(ctx BreadcrumbResolveContext) []Breadcrumb {
+		return cloneBreadcrumbs(ctx.Parent)
+	}
+}
+
+// PolicyBreadcrumbs resolves breadcrumbs from a BreadcrumbPolicy and runtime labels.
+func PolicyBreadcrumbs(policy BreadcrumbPolicy) BreadcrumbSource {
+	return func(ctx BreadcrumbResolveContext) []Breadcrumb {
+		return policy.Resolve(ctx.Path, ctx.RuntimeLabels...)
+	}
+}
+
+// PathBreadcrumbs resolves breadcrumbs from the current path.
+func PathBreadcrumbs() BreadcrumbSource {
+	return func(ctx BreadcrumbResolveContext) []Breadcrumb {
+		return BreadcrumbsFromPath(normalizeCrumbPath(ctx.Path), ctx.PathLabels)
+	}
+}
+
+func cloneBreadcrumbs(crumbs []Breadcrumb) []Breadcrumb {
+	if len(crumbs) == 0 {
+		return nil
+	}
+	copied := make([]Breadcrumb, len(crumbs))
+	copy(copied, crumbs)
+	return copied
+}

--- a/breadcrumb_resolver_test.go
+++ b/breadcrumb_resolver_test.go
@@ -1,0 +1,90 @@
+package linkwell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBreadcrumbResolver_FirstNonEmptySourceWins(t *testing.T) {
+	resolver := NewBreadcrumbResolver(
+		func(BreadcrumbResolveContext) []Breadcrumb { return nil },
+		func(BreadcrumbResolveContext) []Breadcrumb {
+			return []Breadcrumb{{Label: "Explicit", Href: ""}}
+		},
+		PathBreadcrumbs(),
+	)
+	crumbs := resolver.Resolve(BreadcrumbResolveContext{Path: "/fallback"})
+	require.Equal(t, []Breadcrumb{{Label: "Explicit", Href: ""}}, crumbs)
+}
+
+func TestBreadcrumbResolver_ExplicitBeatsPolicyAndPathFallback(t *testing.T) {
+	policy := Breadcrumbs().Prefix("/app").Root("App").Crumb("/users/:id", "Policy User")
+	resolver := NewBreadcrumbResolver(
+		ExplicitBreadcrumbs(),
+		PolicyBreadcrumbs(policy),
+		PathBreadcrumbs(),
+	)
+	crumbs := resolver.Resolve(BreadcrumbResolveContext{
+		Path:     "/app/users/42",
+		Explicit: []Breadcrumb{{Label: "Route Label", Href: ""}},
+		RuntimeLabels: []CrumbOption{
+			CrumbLabel("/users/:id", "Runtime User"),
+		},
+	})
+	require.Equal(t, []Breadcrumb{{Label: "Route Label", Href: ""}}, crumbs)
+}
+
+func TestBreadcrumbResolver_PolicySourceUsesRuntimeLabels(t *testing.T) {
+	policy := Breadcrumbs().Prefix("/app/sales-goals").Root("Sales Goals").
+		Crumb("/agents", "Agents")
+	resolver := NewBreadcrumbResolver(ExplicitBreadcrumbs(), PolicyBreadcrumbs(policy), PathBreadcrumbs())
+	crumbs := resolver.Resolve(BreadcrumbResolveContext{
+		Path: "/app/sales-goals/agents/346",
+		RuntimeLabels: []CrumbOption{
+			CrumbLabel("/agents/:id", "Ashley Pope"),
+		},
+	})
+	require.Equal(t, []string{"Sales Goals", "Agents", "Ashley Pope"}, labels(crumbs))
+	require.Empty(t, crumbs[2].Href)
+}
+
+func TestBreadcrumbResolver_ParentSourceCanPrecedePathFallback(t *testing.T) {
+	resolver := NewBreadcrumbResolver(ExplicitBreadcrumbs(), ParentBreadcrumbs(), PathBreadcrumbs())
+	crumbs := resolver.Resolve(BreadcrumbResolveContext{
+		Path: "/app/reports/42",
+		Parent: []Breadcrumb{
+			{Label: "Reports", Href: "/app/reports"},
+			{Label: "Report 42", Href: ""},
+		},
+	})
+	require.Equal(t, []Breadcrumb{
+		{Label: "Reports", Href: "/app/reports"},
+		{Label: "Report 42", Href: ""},
+	}, crumbs)
+}
+
+func TestBreadcrumbResolver_PathFallback(t *testing.T) {
+	resolver := NewBreadcrumbResolver(ExplicitBreadcrumbs(), ParentBreadcrumbs(), PathBreadcrumbs())
+	crumbs := resolver.Resolve(BreadcrumbResolveContext{
+		Path:       "/users/42/edit?tab=summary",
+		PathLabels: map[int]string{1: "User 42"},
+	})
+	require.Equal(t, []string{"Home", "Users", "User 42", "Edit"}, labels(crumbs))
+	require.Empty(t, crumbs[len(crumbs)-1].Href)
+}
+
+func TestBreadcrumbResolver_ClonesCallerOwnedSlices(t *testing.T) {
+	explicit := []Breadcrumb{{Label: "Original", Href: ""}}
+	resolver := NewBreadcrumbResolver(ExplicitBreadcrumbs())
+	crumbs := resolver.Resolve(BreadcrumbResolveContext{Explicit: explicit})
+	crumbs[0].Label = "Changed"
+	require.Equal(t, "Original", explicit[0].Label)
+
+	resolver = NewBreadcrumbResolver(func(BreadcrumbResolveContext) []Breadcrumb {
+		return explicit
+	})
+	crumbs = resolver.Resolve(BreadcrumbResolveContext{})
+	crumbs[0].Label = "Changed Again"
+	require.Equal(t, "Original", explicit[0].Label)
+}

--- a/nav.go
+++ b/nav.go
@@ -71,16 +71,32 @@ type Breadcrumb struct {
 	Href string
 }
 
+type navMatchConfig struct {
+	pathOnly bool
+}
+
+// NavMatchOption configures active navigation matching.
+type NavMatchOption func(*navMatchConfig)
+
+// MatchPathOnly strips query strings and fragments before active nav matching.
+func MatchPathOnly() NavMatchOption {
+	return func(cfg *navMatchConfig) {
+		cfg.pathOnly = true
+	}
+}
+
 // BreadcrumbLabelHome is the default label for the root breadcrumb segment.
 const BreadcrumbLabelHome = "Home"
 
 // SetActiveNavItem sets the Active flag on nav items using exact path matching.
 // A parent item is also marked active if any of its children match. Returns a
 // new slice; the input is not modified.
-func SetActiveNavItem(items []NavItem, currentPath string) []NavItem {
+func SetActiveNavItem(items []NavItem, currentPath string, opts ...NavMatchOption) []NavItem {
+	cfg := newNavMatchConfig(opts)
+	currentMatchPath := navMatchPath(currentPath, cfg)
 	result := make([]NavItem, len(items))
 	for i, item := range items {
-		item.Children = SetActiveNavItem(item.Children, currentPath)
+		item.Children = SetActiveNavItem(item.Children, currentPath, opts...)
 		childActive := false
 		for _, child := range item.Children {
 			if child.Active {
@@ -88,7 +104,7 @@ func SetActiveNavItem(items []NavItem, currentPath string) []NavItem {
 				break
 			}
 		}
-		item.Active = item.Href == currentPath || childActive
+		item.Active = navMatchPath(item.Href, cfg) == currentMatchPath || childActive
 		result[i] = item
 	}
 	return result
@@ -103,20 +119,23 @@ func SetActiveNavItem(items []NavItem, currentPath string) []NavItem {
 // of sibling selection. Use for section-level navigation where /users should
 // be active when the path is /users/42/edit. Returns a new slice; the input is
 // not modified.
-func SetActiveNavItemPrefix(items []NavItem, currentPath string) []NavItem {
+func SetActiveNavItemPrefix(items []NavItem, currentPath string, opts ...NavMatchOption) []NavItem {
+	cfg := newNavMatchConfig(opts)
+	currentMatchPath := navMatchPath(currentPath, cfg)
 	result := make([]NavItem, len(items))
 	bestIdx := -1
 	bestLen := -1
 	for i, item := range items {
-		item.Children = SetActiveNavItemPrefix(item.Children, currentPath)
+		item.Children = SetActiveNavItemPrefix(item.Children, currentPath, opts...)
 		result[i] = item
+		href := navMatchPath(item.Href, cfg)
 		// Require href+separator to avoid "/" matching every path. Longer Href
 		// means a deeper segment-bounded prefix (exact match is longest), so
 		// len comparison picks the best sibling; ties keep the first item.
-		if item.Href != "" &&
-			(currentPath == item.Href || strings.HasPrefix(currentPath, item.Href+"/")) &&
-			len(item.Href) > bestLen {
-			bestLen = len(item.Href)
+		if href != "" &&
+			(currentMatchPath == href || strings.HasPrefix(currentMatchPath, href+"/")) &&
+			len(href) > bestLen {
+			bestLen = len(href)
 			bestIdx = i
 		}
 	}
@@ -131,6 +150,30 @@ func SetActiveNavItemPrefix(items []NavItem, currentPath string) []NavItem {
 		result[i].Active = i == bestIdx || childActive
 	}
 	return result
+}
+
+func newNavMatchConfig(opts []NavMatchOption) navMatchConfig {
+	var cfg navMatchConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
+}
+
+func navMatchPath(path string, cfg navMatchConfig) string {
+	if cfg.pathOnly {
+		return stripQueryFragment(path)
+	}
+	return path
+}
+
+func stripQueryFragment(path string) string {
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		return path[:i]
+	}
+	return path
 }
 
 // NavItemFromControl converts a Control into a NavItem, mapping Label, Href,

--- a/nav_test.go
+++ b/nav_test.go
@@ -67,6 +67,24 @@ func TestSetActiveNavItem_DoesNotMutateOriginal(t *testing.T) {
 	require.False(t, items[0].Active, "original slice must not be mutated")
 }
 
+func TestSetActiveNavItem_MatchPathOnlyIgnoresQueryAndFragment(t *testing.T) {
+	items := []NavItem{
+		{Label: "Sales Goals", Href: "/app/sales-goals?quarter=2026Q2#summary"},
+		{Label: "Settings", Href: "/settings"},
+	}
+	result := SetActiveNavItem(items, "/app/sales-goals?quarter=2026Q3#thread", MatchPathOnly())
+	require.True(t, result[0].Active)
+	require.False(t, result[1].Active)
+}
+
+func TestSetActiveNavItem_DefaultKeepsQuerySensitiveBehavior(t *testing.T) {
+	items := []NavItem{
+		{Label: "Sales Goals", Href: "/app/sales-goals?quarter=2026Q2"},
+	}
+	result := SetActiveNavItem(items, "/app/sales-goals?quarter=2026Q3")
+	require.False(t, result[0].Active)
+}
+
 // ---------------------------------------------------------------------------
 // SetActiveNavItemPrefix
 // ---------------------------------------------------------------------------
@@ -183,6 +201,32 @@ func TestSetActiveNavItemPrefix_ChildPrefixMatchActivatesParent(t *testing.T) {
 	result := SetActiveNavItemPrefix(items, "/demo/inventory/99")
 	require.True(t, result[0].Active, "parent Tables should be active via child prefix match")
 	require.True(t, result[0].Children[0].Active, "child Inventory should be active via prefix")
+}
+
+func TestSetActiveNavItemPrefix_MatchPathOnlyIgnoresQueryAndFragment(t *testing.T) {
+	items := []NavItem{
+		{Label: "Dashboard", Href: "/app/sales-goals?quarter=2026Q2"},
+		{Label: "Agents", Href: "/app/sales-goals/agents?quarter=2026Q2#list"},
+	}
+	result := SetActiveNavItemPrefix(items, "/app/sales-goals/agents/42?quarter=2026Q3#detail", MatchPathOnly())
+	require.False(t, result[0].Active, "shorter sibling should lose after path-only normalization")
+	require.True(t, result[1].Active)
+}
+
+func TestSetActiveNavItemPrefix_DefaultKeepsQuerySensitiveBehavior(t *testing.T) {
+	items := []NavItem{
+		{Label: "Dashboard", Href: "/app/sales-goals?quarter=2026Q2"},
+	}
+	result := SetActiveNavItemPrefix(items, "/app/sales-goals/agents?quarter=2026Q2")
+	require.False(t, result[0].Active)
+}
+
+func TestSetActiveNavItemPrefix_MatchPathOnlyPreservesSegmentBoundary(t *testing.T) {
+	items := []NavItem{
+		{Label: "Agents", Href: "/agents?tab=current"},
+	}
+	result := SetActiveNavItemPrefix(items, "/agents-old?tab=current", MatchPathOnly())
+	require.False(t, result[0].Active)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add ordered breadcrumb resolver sources for explicit crumbs, parent/up context, BreadcrumbPolicy runtime labels, and path fallback.
- Add `MatchPathOnly()` active nav option for exact and prefix matching while preserving default query-sensitive behavior.
- Cover issue #69 and issue #70 with focused tests.

Fixes #69
Fixes #70

## Validation

- go test ./...
