### PR TITLE
docs: add breadcrumb resolver and path-only nav examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
     - [Title From Path](#title-from-path)
     - [Dynamic Links](#dynamic-links)
   - [Breadcrumbs](#breadcrumbs)
+    - [Declarative Policy](#declarative-policy-recommended)
+    - [Fallback Resolver](#fallback-resolver)
     - [From Link Graph](#from-link-graph)
     - [From URL Path](#from-url-path)
     - [Bitmask Breadcrumbs](#bitmask-breadcrumbs)
@@ -320,6 +322,32 @@ The link-graph and path helpers below remain for sitemap-driven trails and
 simple cases, but the declarative policy is the preferred API for app-local
 breadcrumbs with dynamic labels.
 
+### Fallback Resolver
+
+When one source isn't enough, `NewBreadcrumbResolver` composes ordered sources
+and returns the first non-empty trail. linkwell owns the fallback order; it
+never loads entities. Handlers pass request-local data -- dynamic labels and
+explicit or parent crumbs -- through a `BreadcrumbResolveContext`.
+
+```go
+resolver := linkwell.NewBreadcrumbResolver(
+	linkwell.ExplicitBreadcrumbs(),          // route-provided trail, if any
+	linkwell.PolicyBreadcrumbs(salesCrumbs), // declarative policy + runtime labels
+	linkwell.ParentBreadcrumbs(),            // app-provided parent/up trail
+	linkwell.PathBreadcrumbs(),              // path-derived fallback
+)
+
+crumbs := resolver.Resolve(linkwell.BreadcrumbResolveContext{
+	Path:          "/app/sales-goals/agents/346",
+	RuntimeLabels: []linkwell.CrumbOption{linkwell.CrumbLabel("/agents/:id", "Ashley Pope")},
+})
+// Sales Goals (/app/sales-goals) > Agents (/app/sales-goals/agents) > [Ashley Pope]
+```
+
+Sources are tried in order, so put the most specific first and `PathBreadcrumbs`
+last. `Explicit` and `Parent` trails arrive from the handler as breadcrumb data;
+linkwell composes the order but performs no database or entity lookup.
+
 ### From Link Graph
 
 Walk the `rel="up"` chain from a path to build a breadcrumb trail. Requires links registered via `Hub` or `Link` with `rel="up"`. Registered titles are preserved -- if a spoke was registered with a custom title, that title appears in the breadcrumb instead of the path-derived label.
@@ -514,6 +542,21 @@ items := linkwell.SetActiveNavItemPrefix(nav.Items, "/users/42/edit")
 ```
 
 Both functions handle nested children: a parent is marked active if any child matches.
+
+By default the path is compared verbatim, so a query string or fragment
+prevents a match. Pass `MatchPathOnly()` to strip the query and fragment from
+both the request path and item Hrefs before matching -- useful when filters or
+scope live in the query string (e.g. `?quarter=2026Q3`):
+
+```go
+// Exact match stays active despite the query string.
+items := linkwell.SetActiveNavItem(nav.Items, "/users?tab=active", linkwell.MatchPathOnly())
+
+// Prefix match ignores ?quarter while keeping segment boundaries
+// ("/agents" still won't match "/agents-old").
+items = linkwell.SetActiveNavItemPrefix(nav.Items,
+	"/app/sales-goals/agents?quarter=2026Q3", linkwell.MatchPathOnly())
+```
 
 ## Tabs
 

--- a/example_test.go
+++ b/example_test.go
@@ -186,6 +186,36 @@ func ExampleBreadcrumbs() {
 	// [Atwater Villas]
 }
 
+func ExampleNewBreadcrumbResolver() {
+	policy := linkwell.Breadcrumbs().
+		Prefix("/app/sales-goals").
+		Root("Sales Goals").
+		Crumb("/agents", "Agents")
+
+	resolver := linkwell.NewBreadcrumbResolver(
+		linkwell.ExplicitBreadcrumbs(),
+		linkwell.PolicyBreadcrumbs(policy),
+		linkwell.ParentBreadcrumbs(),
+		linkwell.PathBreadcrumbs(),
+	)
+
+	crumbs := resolver.Resolve(linkwell.BreadcrumbResolveContext{
+		Path:          "/app/sales-goals/agents/346",
+		RuntimeLabels: []linkwell.CrumbOption{linkwell.CrumbLabel("/agents/:id", "Ashley Pope")},
+	})
+	for _, c := range crumbs {
+		if c.Href == "" {
+			fmt.Printf("[%s]\n", c.Label)
+		} else {
+			fmt.Printf("%s (%s)\n", c.Label, c.Href)
+		}
+	}
+	// Output:
+	// Sales Goals (/app/sales-goals)
+	// Agents (/app/sales-goals/agents)
+	// [Ashley Pope]
+}
+
 func ExampleBreadcrumbsFromLinks() {
 	linkwell.ResetForTesting()
 
@@ -310,6 +340,22 @@ func ExampleSetActiveNavItemPrefix() {
 	// Output:
 	// Users active=true
 	// Settings active=false
+}
+
+func ExampleSetActiveNavItemPrefix_matchPathOnly() {
+	items := []linkwell.NavItem{
+		{Label: "Dashboard", Href: "/app/sales-goals"},
+		{Label: "Agents", Href: "/app/sales-goals/agents"},
+	}
+	// The ?quarter filter is ignored; the longest segment-bounded prefix wins.
+	result := linkwell.SetActiveNavItemPrefix(items,
+		"/app/sales-goals/agents/42?quarter=2026Q3", linkwell.MatchPathOnly())
+	for _, item := range result {
+		fmt.Printf("%s active=%v\n", item.Label, item.Active)
+	}
+	// Output:
+	// Dashboard active=false
+	// Agents active=true
 }
 
 func ExampleNavItemFromControl() {

--- a/recipes.md
+++ b/recipes.md
@@ -36,6 +36,40 @@ tabs := linkwell.NewTabConfig("dashboard-tabs", "#tab-content",
 tabs.Items = linkwell.SetActiveTab(tabs.Items, "/dashboard/network")
 ```
 
+### Active nav and breadcrumb fallback with query-scoped views
+
+When views carry scope in the query string (`?quarter=2026Q3`), pass
+`MatchPathOnly()` so the filter does not break active-nav selection, and use a
+`BreadcrumbResolver` to fall back from explicit crumbs to a policy to the path.
+
+```go
+sectionNav := []linkwell.NavItem{
+    {Label: "Subdivisions", Href: "/app/sales-goals/subdivisions", Icon: "map"},
+    {Label: "Agents", Href: "/app/sales-goals/agents", Icon: "users"},
+}
+// "Agents" stays active for "/app/sales-goals/agents/346?quarter=2026Q3".
+sectionNav = linkwell.SetActiveNavItemPrefix(sectionNav, r.URL.RequestURI(), linkwell.MatchPathOnly())
+
+salesCrumbs := linkwell.Breadcrumbs().
+    Prefix("/app/sales-goals").Root("Sales Goals").
+    Crumb("/agents", "Agents")
+
+resolver := linkwell.NewBreadcrumbResolver(
+    linkwell.ExplicitBreadcrumbs(),          // handler-supplied trail wins
+    linkwell.PolicyBreadcrumbs(salesCrumbs), // declarative policy + runtime labels
+    linkwell.ParentBreadcrumbs(),            // app-supplied parent/up trail
+    linkwell.PathBreadcrumbs(),              // last-resort path fallback
+)
+
+crumbs := resolver.Resolve(linkwell.BreadcrumbResolveContext{
+    Path:          r.URL.Path,
+    RuntimeLabels: []linkwell.CrumbOption{linkwell.CrumbLabel("/agents/:id", agent.Name)},
+})
+```
+
+The handler loads `agent.Name`; linkwell only orders the fallback sources and
+never performs the lookup itself.
+
 ### Scheduled widget updates (tavern side)
 
 tavern's `ScheduledPublisher` renders each widget section on independent intervals and publishes the rendered HTML as OOB fragments. The browser receives these via SSE and HTMX swaps them into the page — no polling, no JavaScript state.


### PR DESCRIPTION
## Summary
- document breadcrumb resolver fallback ordering in README
- document MatchPathOnly active nav matching in README
- add executable examples and recipe coverage for resolver + path-only nav

## Validation
- go test ./... -count=1
- go vet ./...
