### PR TITLE
feat: add dynamic origin breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
     - [From Link Graph](#from-link-graph)
     - [From URL Path](#from-url-path)
     - [Bitmask Breadcrumbs](#bitmask-breadcrumbs)
+    - [Dynamic Origin Trail](#dynamic-origin-trail)
   - [Controls](#controls)
     - [Factory Functions](#factory-functions)
     - [Control Modifiers](#control-modifiers)
@@ -393,6 +394,36 @@ crumbs := linkwell.ResolveFromMask(mask)
 href := linkwell.FromNav("/users/42", c.QueryParam("from"))
 // "/users/42?from=3" if mask was 3
 ```
+
+### Dynamic Origin Trail
+
+The `?from=` bitmask replays breadcrumbs registered at startup, so it fits fixed
+origins. When the trail depends on runtime data — an entity name, a filtered
+view, a path the user actually came from — encode it as a dynamic origin trail
+instead. linkwell handles the serialization and validation; apps supply the
+labels and hrefs and own the rendering.
+
+```go
+// Outbound link: forward where the user is coming from.
+trail := []linkwell.OriginCrumb{
+	{Label: "Sales Goals", Href: "/app/sales-goals"},
+	{Label: agent.Name, Href: "/app/sales-goals/agents/" + agent.ID},
+}
+href := linkwell.OriginNav("/app/tasks/new", trail)
+// "/app/tasks/new?origin=<encoded>", existing query and fragment preserved
+
+// Destination handler: decode it back into breadcrumbs.
+if origin, ok := linkwell.OriginTrailFromRequest(r); ok {
+	crumbs := linkwell.OriginCrumbsToBreadcrumbs(origin)
+	_ = crumbs // render with your breadcrumb component
+}
+```
+
+Each crumb's `Href` is validated as a safe same-origin local path with the same
+rules as `ReturnTarget` (absolute URLs, `//host`, backslash bypasses, and
+control characters are rejected); a trail with any invalid crumb is dropped
+whole. An origin trail is display context only — it tells a page where the user
+came from, never where it is safe to redirect. Use `ReturnTarget` for that.
 
 ### Return Targets
 

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package linkwell_test
 
 import (
 	"fmt"
+	"net/http/httptest"
 
 	"github.com/catgoose/linkwell"
 )
@@ -303,6 +304,50 @@ func ExampleReturnTargetFromValue() {
 	// Output:
 	// Back -> /vendors/42?tab=orders (exact=true)
 	// Back to vendors -> /vendors (exact=false)
+}
+
+func ExampleOriginNav() {
+	trail := []linkwell.OriginCrumb{
+		{Label: "Sales Goals", Href: "/app/sales-goals"},
+		{Label: "Agents", Href: "/app/sales-goals/agents"},
+	}
+
+	// Forward dynamic origin context to an outbound link.
+	href := linkwell.OriginNav("/app/sales-goals/agents/346", trail)
+
+	// The destination handler decodes the trail from the request.
+	r := httptest.NewRequest("GET", href, nil)
+	decoded, ok := linkwell.OriginTrailFromRequest(r)
+	fmt.Println(ok)
+	for _, c := range decoded {
+		fmt.Printf("%s -> %s\n", c.Label, c.Href)
+	}
+	// Output:
+	// true
+	// Sales Goals -> /app/sales-goals
+	// Agents -> /app/sales-goals/agents
+}
+
+func ExampleOriginTrailFromValue() {
+	value := linkwell.OriginTrailParam([]linkwell.OriginCrumb{
+		{Label: "Reports", Href: "/reports"},
+		{Label: "Q3", Href: "/reports?quarter=2026Q3"},
+	})
+
+	decoded, ok := linkwell.OriginTrailFromValue(value)
+	fmt.Println(ok)
+	for _, c := range decoded {
+		fmt.Printf("%s -> %s\n", c.Label, c.Href)
+	}
+
+	// An absent or malformed value is rejected as a whole.
+	_, ok = linkwell.OriginTrailFromValue("")
+	fmt.Println(ok)
+	// Output:
+	// true
+	// Reports -> /reports
+	// Q3 -> /reports?quarter=2026Q3
+	// false
 }
 
 func ExampleFromQueryString() {

--- a/origin_trail.go
+++ b/origin_trail.go
@@ -1,0 +1,153 @@
+package linkwell
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// DefaultOriginTrailParam is the query parameter carrying an encoded dynamic
+// origin breadcrumb trail.
+//
+// A dynamic origin trail forwards runtime breadcrumb labels and hrefs through a
+// link so a destination reached from several places can show where the user came
+// from. It complements the static ?from= bitmask (see FromNav), which replays
+// breadcrumbs registered at startup. Like ?from=, an origin trail is display
+// context, never a redirect authorization — use ReturnTarget for safe returns.
+const DefaultOriginTrailParam = "origin"
+
+// Bounds on a decoded or encoded origin trail so hostile query values cannot
+// force unbounded work. The encoded cap is checked against the base64 value.
+const (
+	maxOriginTrailEncodedLen = 2048
+	maxOriginCrumbCount      = 16
+	maxOriginLabelLen        = 128
+	maxOriginHrefLen         = 512
+)
+
+// OriginCrumb is one segment of a dynamic origin breadcrumb trail. Label is
+// display text; Href is a safe same-origin local path validated with the same
+// rules as ReturnTarget. Field order is preserved end to end.
+type OriginCrumb struct {
+	Label string `json:"l"`
+	Href  string `json:"h"`
+}
+
+// OriginTrailParam encodes an ordered origin trail into a URL-safe query
+// parameter value. It returns "" when the trail is empty or any crumb is invalid
+// (empty label or an href that is not a safe same-origin path), so anything it
+// emits round-trips through OriginTrailFromValue.
+func OriginTrailParam(trail []OriginCrumb) string {
+	if len(trail) == 0 {
+		return ""
+	}
+	clean, ok := sanitizeOriginTrail(trail)
+	if !ok {
+		return ""
+	}
+	data, err := json.Marshal(clean)
+	if err != nil {
+		return ""
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+	if len(encoded) > maxOriginTrailEncodedLen {
+		return ""
+	}
+	return encoded
+}
+
+// OriginTrailFromValue decodes and validates an already-extracted origin trail
+// parameter value. It returns the ordered crumbs and true only when decoding
+// succeeds and every crumb has a non-empty label and a safe same-origin href;
+// otherwise it returns (nil, false). Use when the value is read outside
+// net/http.
+func OriginTrailFromValue(raw string) ([]OriginCrumb, bool) {
+	if raw == "" || len(raw) > maxOriginTrailEncodedLen {
+		return nil, false
+	}
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, false
+	}
+	var trail []OriginCrumb
+	if err := json.Unmarshal(data, &trail); err != nil {
+		return nil, false
+	}
+	return sanitizeOriginTrail(trail)
+}
+
+// OriginTrailFromRequest decodes the origin trail carried in the request's
+// DefaultOriginTrailParam query parameter. A nil request or an absent or invalid
+// value returns (nil, false).
+func OriginTrailFromRequest(r *http.Request) ([]OriginCrumb, bool) {
+	if r == nil {
+		return nil, false
+	}
+	return OriginTrailFromValue(r.URL.Query().Get(DefaultOriginTrailParam))
+}
+
+// OriginNav appends an encoded origin trail to href as the
+// DefaultOriginTrailParam query parameter, preserving any existing query string
+// and fragment. href is returned unchanged when the trail is empty or cannot be
+// encoded safely.
+func OriginNav(href string, trail []OriginCrumb) string {
+	value := OriginTrailParam(trail)
+	if value == "" {
+		return href
+	}
+	return appendQueryParam(href, DefaultOriginTrailParam, value)
+}
+
+// OriginCrumbsToBreadcrumbs converts a decoded origin trail into a breadcrumb
+// trail for rendering or for use as a BreadcrumbResolver source. Every segment
+// keeps its href; linkwell does not load entity labels.
+func OriginCrumbsToBreadcrumbs(trail []OriginCrumb) []Breadcrumb {
+	if len(trail) == 0 {
+		return nil
+	}
+	crumbs := make([]Breadcrumb, len(trail))
+	for i, c := range trail {
+		crumbs[i] = Breadcrumb(c)
+	}
+	return crumbs
+}
+
+// sanitizeOriginTrail trims labels and validates every crumb against the origin
+// trail bounds and the safe-local-path rules. It rejects the whole trail when it
+// is empty, too long, or any crumb is invalid.
+func sanitizeOriginTrail(trail []OriginCrumb) ([]OriginCrumb, bool) {
+	if len(trail) == 0 || len(trail) > maxOriginCrumbCount {
+		return nil, false
+	}
+	out := make([]OriginCrumb, 0, len(trail))
+	for _, c := range trail {
+		label := strings.TrimSpace(c.Label)
+		if label == "" || len(label) > maxOriginLabelLen {
+			return nil, false
+		}
+		if len(c.Href) > maxOriginHrefLen {
+			return nil, false
+		}
+		href, ok := safeLocalPath(c.Href)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, OriginCrumb{Label: label, Href: href})
+	}
+	return out, true
+}
+
+// appendQueryParam appends key=value to href, keeping any existing query string
+// and moving the result before a fragment. value must already be URL-safe.
+func appendQueryParam(href, key, value string) string {
+	target, fragment := href, ""
+	if i := strings.IndexByte(href, '#'); i >= 0 {
+		target, fragment = href[:i], href[i:]
+	}
+	sep := "?"
+	if strings.IndexByte(target, '?') >= 0 {
+		sep = "&"
+	}
+	return target + sep + key + "=" + value + fragment
+}

--- a/origin_trail_test.go
+++ b/origin_trail_test.go
@@ -1,0 +1,129 @@
+package linkwell
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOriginTrail_RoundTripPreservesOrderLabelsHrefs(t *testing.T) {
+	trail := []OriginCrumb{
+		{Label: "Sales Goals", Href: "/app/sales-goals"},
+		{Label: "Agents", Href: "/app/sales-goals/agents?quarter=2026Q3"},
+		{Label: "Ashley Pope", Href: "/app/sales-goals/agents/346"},
+	}
+	value := OriginTrailParam(trail)
+	require.NotEmpty(t, value)
+
+	decoded, ok := OriginTrailFromValue(value)
+	require.True(t, ok)
+	require.Equal(t, trail, decoded)
+}
+
+func TestOriginTrail_TrimsLabels(t *testing.T) {
+	value := OriginTrailParam([]OriginCrumb{{Label: "  Agents  ", Href: "/agents"}})
+	decoded, ok := OriginTrailFromValue(value)
+	require.True(t, ok)
+	require.Equal(t, []OriginCrumb{{Label: "Agents", Href: "/agents"}}, decoded)
+}
+
+func TestOriginTrail_RejectsInvalidCrumbs(t *testing.T) {
+	cases := map[string]OriginCrumb{
+		"absolute URL":      {Label: "Ext", Href: "https://evil.example/x"},
+		"protocol-relative": {Label: "Ext", Href: "//evil.example/x"},
+		"backslash bypass":  {Label: "Ext", Href: "/\\evil.example"},
+		"raw backslash":     {Label: "Ext", Href: "/app\\admin"},
+		"raw control char":  {Label: "Ext", Href: "/app\x01admin"},
+		"escaped backslash": {Label: "Ext", Href: "/app%5Cadmin"},
+		"escaped control":   {Label: "Ext", Href: "/app%01admin"},
+		"empty label":       {Label: "   ", Href: "/agents"},
+		"empty href":        {Label: "Agents", Href: ""},
+		"relative href":     {Label: "Agents", Href: "agents"},
+		"oversized label":   {Label: strings.Repeat("a", maxOriginLabelLen+1), Href: "/agents"},
+		"oversized href":    {Label: "Agents", Href: "/" + strings.Repeat("a", maxOriginHrefLen)},
+	}
+	for name, crumb := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Empty(t, OriginTrailParam([]OriginCrumb{crumb}), "encode should reject")
+
+			value := base64.RawURLEncoding.EncodeToString([]byte(
+				`[{"l":"` + crumb.Label + `","h":"` + crumb.Href + `"}]`))
+			_, ok := OriginTrailFromValue(value)
+			require.False(t, ok, "decode should reject")
+		})
+	}
+}
+
+func TestOriginTrail_RejectsTooManyCrumbs(t *testing.T) {
+	trail := make([]OriginCrumb, maxOriginCrumbCount+1)
+	for i := range trail {
+		trail[i] = OriginCrumb{Label: "Crumb", Href: "/crumb"}
+	}
+	require.Empty(t, OriginTrailParam(trail))
+}
+
+func TestOriginTrailFromValue_RejectsMalformedAndOversized(t *testing.T) {
+	_, ok := OriginTrailFromValue("not*base64*")
+	require.False(t, ok)
+
+	_, ok = OriginTrailFromValue(base64.RawURLEncoding.EncodeToString([]byte("{not json")))
+	require.False(t, ok)
+
+	_, ok = OriginTrailFromValue(strings.Repeat("A", maxOriginTrailEncodedLen+1))
+	require.False(t, ok)
+
+	_, ok = OriginTrailFromValue("")
+	require.False(t, ok)
+}
+
+func TestOriginTrailFromRequest_ReadsDefaultParam(t *testing.T) {
+	value := OriginTrailParam([]OriginCrumb{{Label: "Agents", Href: "/agents"}})
+	r := httptest.NewRequest("GET", "/agents/346?"+DefaultOriginTrailParam+"="+value, nil)
+	decoded, ok := OriginTrailFromRequest(r)
+	require.True(t, ok)
+	require.Equal(t, []OriginCrumb{{Label: "Agents", Href: "/agents"}}, decoded)
+
+	_, ok = OriginTrailFromRequest(nil)
+	require.False(t, ok)
+
+	_, ok = OriginTrailFromRequest(httptest.NewRequest("GET", "/agents/346", nil))
+	require.False(t, ok)
+}
+
+func TestOriginNav_PreservesQueryAndFragment(t *testing.T) {
+	trail := []OriginCrumb{{Label: "Agents", Href: "/agents"}}
+	value := OriginTrailParam(trail)
+
+	require.Equal(t, "/agents/346?"+DefaultOriginTrailParam+"="+value,
+		OriginNav("/agents/346", trail))
+	require.Equal(t, "/agents/346?tab=stats&"+DefaultOriginTrailParam+"="+value,
+		OriginNav("/agents/346?tab=stats", trail))
+	require.Equal(t, "/agents/346?"+DefaultOriginTrailParam+"="+value+"#summary",
+		OriginNav("/agents/346#summary", trail))
+
+	require.Equal(t, "/agents/346", OriginNav("/agents/346", nil))
+}
+
+func TestOriginCrumbsToBreadcrumbs(t *testing.T) {
+	require.Nil(t, OriginCrumbsToBreadcrumbs(nil))
+	require.Equal(t,
+		[]Breadcrumb{{Label: "Agents", Href: "/agents"}},
+		OriginCrumbsToBreadcrumbs([]OriginCrumb{{Label: "Agents", Href: "/agents"}}))
+}
+
+func TestFromNav_StaticBehaviorUnchanged(t *testing.T) {
+	require.Equal(t, "/users/42", FromNav("/users/42", ""))
+	require.Equal(t, "/users/42?from=3", FromNav("/users/42", "3"))
+	require.Equal(t, "/users/42?tab=x&from=3", FromNav("/users/42?tab=x", "3"))
+
+	ResetForTesting()
+	RegisterFrom(FromDashboard, Breadcrumb{Label: "Dashboard", Href: "/dashboard"})
+	crumbs := ResolveFromMask(FromDashboard)
+	require.Equal(t, []Breadcrumb{
+		{Label: BreadcrumbLabelHome, Href: "/"},
+		{Label: "Dashboard", Href: "/dashboard"},
+	}, crumbs)
+}


### PR DESCRIPTION
## Summary
- add dynamic origin breadcrumb trail encoding/decoding for cross-context navigation
- validate origin crumb hrefs with same safe local path rules as ReturnTarget
- add OriginNav helper, conversion to Breadcrumb, examples, docs, and safety tests

Closes #75.

## Validation
- go test ./... -count=1
- go vet ./...
- go test ./... -run 'OriginTrail|OriginNav|OriginCrumbs|FromNav_Static|ExampleOrigin' -count=1 -v\n